### PR TITLE
Simplify publishing user testing logs in Bublik

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ ts/doxygen.warn
 ts/package.dox
 vg.test.*
 ts/doc/generated
+te_run_meta.json

--- a/jenkins/run
+++ b/jenkins/run
@@ -61,16 +61,6 @@ teTsPipeline {
     }
 
     preRunHook = {
-        def rx_dp = (params.dev_args =~ /^.*rx_datapath=([^,]*).*$/).findAll()
-        def tx_dp = (params.dev_args =~ /^.*tx_datapath=([^,]*).*$/).findAll()
-
-        metas.REUSE_PCO = params.reuse_pco ? 'true' : 'false'
-        metas.DEV_ARGS = params.dev_args
-        metas.RX_DATAPATH = rx_dp.isEmpty() ? "" : rx_dp.first().last()
-        metas.TX_DATAPATH = tx_dp.isEmpty() ? "" : tx_dp.first().last()
-        metas.EAL_ARGS = params.eal_args
-        metas.MODE = params.mode
-
         teDPDK.checkout(ctx: teCtx)
         env.RTE_SDK = teCtx.DPDK_SRC
     }

--- a/scripts/publish_logs
+++ b/scripts/publish_logs
@@ -1,0 +1,11 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2023 OKTET Labs Ltd. All rights reserved.
+#
+# Publish logs from the last testing.
+
+source "$(dirname "$(which "$0")")"/guess.sh
+
+source "${TE_TS_RIGSDIR}/scripts/publish_logs/ts_publish"
+
+tsrigs_publish_do "dpdk-ethdev-ts" "$@"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -134,15 +134,15 @@ function process_cfg() {
 
     case "${cfg}" in
         cmod-rhsim-ef100|cmod-rhsim-virtio)
-            process_cmod_vm "$@" ; CFG= ;;
+            process_cmod_vm "$@" ;;
         cmod-virtio-net)
-            process_cmod "$@" ; CFG= ;;
+            process_cmod "$@" ;;
         rheadington)
-            process_cmod "$@" ; CFG= ;;
+            process_cmod "$@" ;;
         virtio_tap)
-            process_virtio TE_TST1 "$@" ; CFG= ;;
+            process_virtio TE_TST1 "$@" ;;
         virtio_virtio)
-            process_virtio TE_HYPERVISOR "$@" ; CFG= ;;
+            process_virtio TE_HYPERVISOR "$@" ;;
         *)
             call_if_defined grab_cfg_process "${cfg}" || exit 1 ;;
     esac

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -66,6 +66,7 @@ EOF
   --tst-dpdk-drv=<NAME>     DPDK-compatible driver to be used on TST agent
 
   --no-meta                 Do not generate testing metadata
+  --publish                 Publish testing logs to Bublik
 
 EOF
 "${TE_BASE}"/dispatcher.sh --help
@@ -232,6 +233,11 @@ for opt ; do
         --no-meta)
             TE_RUN_META=no
             RUN_OPTS+=("${opt}")
+            ;;
+        --publish)
+            source "${TE_TS_RIGSDIR}/scripts/publish_logs/ts_publish"
+            pscript="$(tsrigs_publish_get dpdk-ethdev-ts)"
+            RUN_OPTS+=("--publish=${pscript}")
             ;;
         *)  RUN_OPTS+=("${opt}") ;;
     esac


### PR DESCRIPTION
Move meta data generation from Jenkins to TS run.sh and dispatcher.sh. Requires test-environment v1.22.0.