### PR TITLE
jenkins: do not spam about successfull updates

### DIFF
--- a/jenkins/update
+++ b/jenkins/update
@@ -13,6 +13,7 @@ teTsPipeline {
 
     tsconf = true
     sticky_repo_params = true
+    email_conditions = [ 'unsuccessful', 'fixed' ]
 
     teEmail.email_add_to_by_ids(teCtx, "DPDK_ETHDEV_TS")
 


### PR DESCRIPTION
There is no point to send E-mail after each successfull update. Notify about unsuccessfull and fixed only.