### PR TITLE
Classify all i40e testing results and fix few issues with virtio-net

### DIFF
--- a/scripts/trc-status.sh
+++ b/scripts/trc-status.sh
@@ -42,8 +42,10 @@ SN1022_EF100_TAGS+=(rx-datapath-ef100 tx-datapath-ef100)
 # Number of VFs should be greater than zero
 SN1022_EF100_TAGS+=(num_vfs:1)
 
+declare -a SN1022_EF100_OPTS2
+SN1022_EF100_OPTS2=("${OPTS2[@]}")
 for tag in "${SN1022_EF100_TAGS[@]}" ; do
-    OPTS2+=(-2 "${tag}")
+    SN1022_EF100_OPTS2+=(-2 "${tag}")
 done
 
 declare -a SN1022_EF100_STATUS_OPTS
@@ -52,7 +54,7 @@ SN1022_EF100_STATUS_OPTS+=(--1-name="Reference")
 SN1022_EF100_STATUS_OPTS+=("${OPTS1[@]}")
 SN1022_EF100_STATUS_OPTS+=(--2-name="SN1022")
 SN1022_EF100_STATUS_OPTS+=(--2-show-keys)
-SN1022_EF100_STATUS_OPTS+=("${OPTS2[@]}")
+SN1022_EF100_STATUS_OPTS+=("${SN1022_EF100_OPTS2[@]}")
 
 te-trc-diff \
     --html=SN1022-EF100-DPDK-${DPDK_VER}-full.html \
@@ -105,4 +107,39 @@ te-trc-diff \
     --html=SN1022-Virtio-Net-DPDK-${DPDK_VER}-short.html \
     --title="SN1022 Virtio-Net in DPDK ${DPDK_VER} short status" \
     "${SN1022_VNET_STATUS_OPTS[@]}" \
+    "${SHORT_EXCLUDE_OPTS[@]}"
+
+
+#
+# i40e status
+#
+
+declare -a I40E_TAGS
+I40E_TAGS+=(net_i40e pci-8086 pci-8086-1572 pci-8086-1583)
+# Number of VFs should be greater than zero
+I40E_TAGS+=(num_vfs:1)
+
+declare -a I40E_OPTS2
+I40E_OPTS2=("${OPTS2[@]}")
+for tag in "${I40E_TAGS[@]}" ; do
+    I40E_OPTS2+=(-2 "${tag}")
+done
+
+declare -a I40E_STATUS_OPTS
+I40E_STATUS_OPTS+=("${COMMON_OPTS[@]}")
+I40E_STATUS_OPTS+=(--1-name="Reference")
+I40E_STATUS_OPTS+=("${OPTS1[@]}")
+I40E_STATUS_OPTS+=(--2-name="i40e")
+I40E_STATUS_OPTS+=(--2-show-keys)
+I40E_STATUS_OPTS+=("${I40E_OPTS2[@]}")
+
+te-trc-diff \
+    --html=i40e-DPDK-${DPDK_VER}-full.html \
+    --title="i40e in DPDK ${DPDK_VER} status" \
+    "${I40E_STATUS_OPTS[@]}"
+
+te-trc-diff \
+    --html=i40e-DPDK-${DPDK_VER}-short.html \
+    --title="i40e in DPDK ${DPDK_VER} short status" \
+    "${I40E_STATUS_OPTS[@]}" \
     "${SHORT_EXCLUDE_OPTS[@]}"

--- a/trc/filters.xml
+++ b/trc/filters.xml
@@ -14043,6 +14043,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="ref://dpdk-bz/1340" notes="net/i40e does not support flow pattern with destination MAC in L2 case">
+          <result value="FAILED">
+            <verdict>Known but unexpected packets recevied</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -14077,6 +14082,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="ref://dpdk-bz/1340" notes="net/i40e does not support flow pattern with destination MAC in L2 case">
+          <result value="FAILED">
+            <verdict>Known but unexpected packets recevied</verdict>
           </result>
         </results>
       </iter>

--- a/trc/filters.xml
+++ b/trc/filters.xml
@@ -14376,6 +14376,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-DEC-TTL" notes="net/i40e does not support TTL decrement action">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid action.</verdict>
+          </result>
+        </results>
       </iter>
     </test>
 

--- a/trc/filters.xml
+++ b/trc/filters.xml
@@ -3468,6 +3468,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -3572,6 +3577,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
           </result>
         </results>
       </iter>
@@ -11731,6 +11741,11 @@
             <verdict>The tunnel type is unsupported</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE">
+          <result value="FAILED">
+            <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count"/>
@@ -11836,6 +11851,11 @@
         <results tags="pci-8086-159b" key="NO-GENEVE" notes="ice does not support GENEVE tunnels">
           <result value="SKIPPED">
             <verdict>The tunnel type is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE">
+          <result value="FAILED">
+            <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
       </iter>
@@ -12848,6 +12868,11 @@
             <verdict>The tunnel type is unsupported</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE">
+          <result value="FAILED">
+            <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count"/>
@@ -12953,6 +12978,11 @@
         <results tags="pci-8086-159b" key="NO-GENEVE" notes="ice does not support GENEVE tunnels">
           <result value="SKIPPED">
             <verdict>The tunnel type is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE">
+          <result value="FAILED">
+            <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
       </iter>

--- a/trc/filters.xml
+++ b/trc/filters.xml
@@ -2376,6 +2376,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -2402,6 +2407,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
           </result>
         </results>
       </iter>
@@ -2437,6 +2447,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -2463,6 +2478,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
           </result>
         </results>
       </iter>
@@ -2981,6 +3001,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -3047,6 +3072,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -3073,6 +3103,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
           </result>
         </results>
       </iter>
@@ -3108,6 +3143,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -3134,6 +3174,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
           </result>
         </results>
       </iter>
@@ -3371,6 +3416,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -3450,6 +3500,11 @@
         <results tags="vdev-failsafe&amp;rx-full-featured&amp;!pci-1924-0903&amp;!pci-1924-1903&amp;!pci-1924-0923&amp;!pci-1924-1923">
           <result value="SKIPPED">
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
           </result>
         </results>
       </iter>
@@ -3863,6 +3918,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -3889,6 +3949,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
           </result>
         </results>
       </iter>
@@ -3957,6 +4022,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -3983,6 +4053,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
           </result>
         </results>
       </iter>
@@ -4318,6 +4393,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count">FALSE</arg>
@@ -4342,6 +4422,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
           </result>
         </results>
       </iter>
@@ -4375,6 +4460,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count">FALSE</arg>
@@ -4399,6 +4489,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
           </result>
         </results>
       </iter>
@@ -5276,6 +5371,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count">FALSE</arg>
@@ -5307,6 +5407,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count">FALSE</arg>
@@ -5817,6 +5922,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count">FALSE</arg>
@@ -5841,6 +5951,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
           </result>
         </results>
       </iter>
@@ -5874,6 +5989,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count">FALSE</arg>
@@ -5898,6 +6018,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
           </result>
         </results>
       </iter>
@@ -6446,6 +6571,11 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count"/>
@@ -6627,6 +6757,11 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count"/>
@@ -6651,6 +6786,11 @@
         <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
           <result value="FAILED">
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
           </result>
         </results>
       </iter>
@@ -6741,6 +6881,11 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count"/>
@@ -6765,6 +6910,11 @@
         <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
           <result value="FAILED">
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
           </result>
         </results>
       </iter>
@@ -7217,6 +7367,11 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count"/>
@@ -7398,6 +7553,11 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count"/>
@@ -7422,6 +7582,11 @@
         <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
           <result value="FAILED">
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
           </result>
         </results>
       </iter>
@@ -7512,6 +7677,11 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count"/>
@@ -7536,6 +7706,11 @@
         <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
           <result value="FAILED">
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
           </result>
         </results>
       </iter>
@@ -8909,6 +9084,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count">TRUE</arg>
@@ -9085,6 +9265,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count">TRUE</arg>
@@ -9109,6 +9294,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
           </result>
         </results>
       </iter>
@@ -9199,6 +9389,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count">TRUE</arg>
@@ -9223,6 +9418,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
           </result>
         </results>
       </iter>
@@ -11250,6 +11450,11 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count"/>
@@ -11347,6 +11552,11 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count"/>
@@ -11442,6 +11652,11 @@
         <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
           <result value="FAILED">
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
           </result>
         </results>
       </iter>
@@ -11549,6 +11764,11 @@
         <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
           <result value="FAILED">
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
           </result>
         </results>
       </iter>
@@ -12367,6 +12587,11 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count"/>
@@ -12474,6 +12699,11 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count"/>
@@ -12569,6 +12799,11 @@
         <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
           <result value="FAILED">
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
           </result>
         </results>
       </iter>
@@ -12676,6 +12911,11 @@
         <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
           <result value="FAILED">
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
           </result>
         </results>
       </iter>
@@ -13439,6 +13679,11 @@
             <verdict>'rte_flow_validate' operation failed: Action is not supported</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count">TRUE</arg>
@@ -13501,6 +13746,11 @@
             <verdict>'rte_flow_validate' operation failed: Action is not supported</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count">TRUE</arg>
@@ -13561,6 +13811,11 @@
         <results tags="pci-1924">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Action is not supported</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
           </result>
         </results>
       </iter>
@@ -13802,6 +14057,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
       </iter>
     </test>
 
@@ -13927,6 +14187,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -14016,6 +14281,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -14105,6 +14375,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -14212,6 +14487,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
           </result>
         </results>
       </iter>

--- a/trc/filters.xml
+++ b/trc/filters.xml
@@ -14088,6 +14088,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-FLAG-MARK-QUEUE" notes="net/i40e does not support action QUEUE after FLAG/MARK">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid action.</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -14110,6 +14115,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-FLAG-MARK-QUEUE" notes="net/i40e does not support action QUEUE after FLAG/MARK">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid action.</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -14130,6 +14140,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-FLAG-MARK-QUEUE" notes="net/i40e does not support action QUEUE after FLAG/MARK">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid action.</verdict>
           </result>
         </results>
       </iter>
@@ -14155,6 +14170,11 @@
         <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
           <result value="FAILED">
             <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-FLAG-MARK-QUEUE" notes="net/i40e does not support action QUEUE after FLAG/MARK">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid action.</verdict>
           </result>
         </results>
       </iter>
@@ -14216,6 +14236,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-FLAG-MARK-QUEUE" notes="net/i40e does not support action QUEUE after FLAG/MARK">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid action.</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -14238,6 +14263,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-FLAG-MARK-QUEUE" notes="net/i40e does not support action QUEUE after FLAG/MARK">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid action.</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -14258,6 +14288,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-FLAG-MARK-QUEUE" notes="net/i40e does not support action QUEUE after FLAG/MARK">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid action.</verdict>
           </result>
         </results>
       </iter>
@@ -14334,6 +14369,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-FLAG-MARK-QUEUE" notes="net/i40e does not support action QUEUE after FLAG/MARK">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid action.</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -14354,6 +14394,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-FLAG-MARK-QUEUE" notes="net/i40e does not support action QUEUE after FLAG/MARK">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid action.</verdict>
           </result>
         </results>
       </iter>
@@ -14428,6 +14473,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-FLAG-MARK-QUEUE" notes="net/i40e does not support action QUEUE after FLAG/MARK">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid action.</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -14448,6 +14498,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-FLAG-MARK-QUEUE" notes="net/i40e does not support action QUEUE after FLAG/MARK">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid action.</verdict>
           </result>
         </results>
       </iter>
@@ -14532,6 +14587,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-FLAG-MARK-QUEUE" notes="net/i40e does not support action QUEUE after FLAG/MARK">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid action.</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -14557,6 +14617,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-FLAG-MARK-QUEUE" notes="net/i40e does not support action QUEUE after FLAG/MARK">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid action.</verdict>
           </result>
         </results>
       </iter>

--- a/trc/filters.xml
+++ b/trc/filters.xml
@@ -3239,6 +3239,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-TUNNEL-PF-VF-ONLY" notes="net/i40e requires tunnel filters PF or VF action">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Not supported action.</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -3333,6 +3338,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-TUNNEL-PF-VF-ONLY" notes="net/i40e requires tunnel filters PF or VF action">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Not supported action.</verdict>
           </result>
         </results>
       </iter>
@@ -3818,6 +3828,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-TUNNEL-PF-VF-ONLY" notes="net/i40e requires tunnel filters PF or VF action">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Not supported action.</verdict>
           </result>
         </results>
       </iter>
@@ -11973,6 +11988,11 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-TUNNEL-PF-VF-ONLY" notes="net/i40e requires tunnel filters PF or VF action">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Not supported action.</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count"/>
@@ -12272,6 +12292,11 @@
         <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
           <result value="FAILED">
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-TUNNEL-PF-VF-ONLY" notes="net/i40e requires tunnel filters PF or VF action">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Not supported action.</verdict>
           </result>
         </results>
       </iter>
@@ -12573,6 +12598,11 @@
         <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
           <result value="FAILED">
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-TUNNEL-PF-VF-ONLY" notes="net/i40e requires tunnel filters PF or VF action">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Not supported action.</verdict>
           </result>
         </results>
       </iter>
@@ -13314,6 +13344,11 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-TUNNEL-PF-VF-ONLY" notes="net/i40e requires tunnel filters PF or VF action">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Not supported action.</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count"/>
@@ -13419,6 +13454,11 @@
         <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
           <result value="FAILED">
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-TUNNEL-PF-VF-ONLY" notes="net/i40e requires tunnel filters PF or VF action">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Not supported action.</verdict>
           </result>
         </results>
       </iter>
@@ -13710,6 +13750,11 @@
         <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
           <result value="FAILED">
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-TUNNEL-PF-VF-ONLY" notes="net/i40e requires tunnel filters PF or VF action">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Not supported action.</verdict>
           </result>
         </results>
       </iter>
@@ -13746,6 +13791,11 @@
         <results tags="pci-8086-159b" key="FLOW-ISOLATE" notes="net/ice does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-TUNNEL-PF-VF-ONLY" notes="net/i40e requires tunnel filters PF or VF action">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Not supported action.</verdict>
           </result>
         </results>
       </iter>

--- a/trc/filters.xml
+++ b/trc/filters.xml
@@ -14981,13 +14981,29 @@
       </iter>
     </test>
     <test name="flow_rule_encap_on_egress" type="script">
-      <objective>Check that encapsulation actions on egress are carried out correctly</objective>
+      <objective>Check that flow API encap action on egress is carried out correctly</objective>
       <notes/>
       <iter result="PASSED">
         <arg name="env"/>
         <arg name="tunnel_type"/>
         <arg name="flow_rule_pattern"/>
-        <arg name="encap_header"/>
+        <arg name="encap_header">{
+                  eth:{
+                    dst-addr plain:'00 01 02 03 04 08'H,
+                    src-addr plain:'00 01 02 03 04 09'H
+                  },
+                  ip4:{
+                    dst-addr plain:'08 08 08 08'H,
+                    src-addr plain:'08 08 08 08'H
+                  },
+                  udp:{
+                    dst-port plain:4789,
+                    src-port plain:55761
+                  },
+                  vxlan:{
+                    vni plain:13
+                  }
+                }</arg>
         <arg name="count"/>
         <notes/>
         <results tags="pci-1924">
@@ -15003,6 +15019,55 @@
         <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
           <result value="FAILED">
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="tunnel_type"/>
+        <arg name="flow_rule_pattern"/>
+        <arg name="encap_header">{
+                  eth:{
+                    dst-addr plain:'00 01 02 03 04 08'H,
+                    src-addr plain:'00 01 02 03 04 09'H
+                  },
+                  ip4:{
+                    dst-addr plain:'08 08 08 08'H,
+                    src-addr plain:'08 08 08 08'H
+                  },
+                  udp:{
+                    dst-port plain:4789,
+                    src-port plain:49152
+                  },
+                  vxlan:{
+                    vni plain:13
+                  }
+                }</arg>
+        <arg name="count"/>
+        <notes/>
+        <results tags="pci-1924">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-ETH-NO-ETHERTYPE" notes="net/i40e does not support flow pattern item ETH without EtherType">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid type mask.</verdict>
           </result>
         </results>
       </iter>

--- a/trc/filters.xml
+++ b/trc/filters.xml
@@ -1784,6 +1784,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: L2 and L3 input set are exclusive.</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -1815,6 +1820,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: L2 and L3 input set are exclusive.</verdict>
           </result>
         </results>
       </iter>
@@ -1855,6 +1865,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -1886,6 +1901,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
           </result>
         </results>
       </iter>
@@ -1924,6 +1944,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
           </result>
         </results>
       </iter>
@@ -2008,6 +2033,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -2046,6 +2076,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -2077,6 +2112,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
           </result>
         </results>
       </iter>
@@ -2117,6 +2157,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -2148,6 +2193,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
           </result>
         </results>
       </iter>
@@ -5479,6 +5529,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: L2 and L3 input set are exclusive.</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count">FALSE</arg>
@@ -5510,6 +5565,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: L2 and L3 input set are exclusive.</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count">FALSE</arg>
@@ -5608,6 +5668,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count">FALSE</arg>
@@ -5637,6 +5702,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
           </result>
         </results>
       </iter>
@@ -5675,6 +5745,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count">FALSE</arg>
@@ -5704,6 +5779,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
           </result>
         </results>
       </iter>
@@ -5856,6 +5936,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count">FALSE</arg>
@@ -5885,6 +5970,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
           </result>
         </results>
       </iter>
@@ -5923,6 +6013,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count">FALSE</arg>
@@ -5952,6 +6047,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
           </result>
         </results>
       </iter>
@@ -6403,6 +6503,11 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count"/>
@@ -6427,6 +6532,11 @@
         <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
           <result value="FAILED">
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
           </result>
         </results>
       </iter>
@@ -6455,6 +6565,11 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: L2 and L3 input set are exclusive.</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count"/>
@@ -6479,6 +6594,11 @@
         <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
           <result value="FAILED">
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
           </result>
         </results>
       </iter>
@@ -6559,6 +6679,11 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count"/>
@@ -6583,6 +6708,11 @@
         <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
           <result value="FAILED">
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
           </result>
         </results>
       </iter>
@@ -6663,6 +6793,11 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count"/>
@@ -6687,6 +6822,11 @@
         <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
           <result value="FAILED">
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
           </result>
         </results>
       </iter>
@@ -7134,6 +7274,11 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count"/>
@@ -7158,6 +7303,11 @@
         <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
           <result value="FAILED">
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
           </result>
         </results>
       </iter>
@@ -7186,6 +7336,11 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: L2 and L3 input set are exclusive.</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count"/>
@@ -7210,6 +7365,11 @@
         <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
           <result value="FAILED">
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
           </result>
         </results>
       </iter>
@@ -7290,6 +7450,11 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count"/>
@@ -7314,6 +7479,11 @@
         <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
           <result value="FAILED">
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
           </result>
         </results>
       </iter>
@@ -7394,6 +7564,11 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count"/>
@@ -7418,6 +7593,11 @@
         <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
           <result value="FAILED">
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
           </result>
         </results>
       </iter>
@@ -8781,6 +8961,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count">TRUE</arg>
@@ -8805,6 +8990,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
           </result>
         </results>
       </iter>
@@ -8833,6 +9023,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: L2 and L3 input set are exclusive.</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count">TRUE</arg>
@@ -8857,6 +9052,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
           </result>
         </results>
       </iter>
@@ -8937,6 +9137,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count">TRUE</arg>
@@ -8961,6 +9166,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
           </result>
         </results>
       </iter>
@@ -9041,6 +9251,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count">TRUE</arg>
@@ -9065,6 +9280,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
           </result>
         </results>
       </iter>
@@ -14099,9 +14319,9 @@
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
-        <arg name="flow_rule_pattern"/>
+        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.dst_mac</arg>
         <arg name="n_counters"/>
-        <arg name="field_path">0.#eth.dst-addr.#plain</arg>
+        <arg name="field_path"/>
         <notes/>
         <results tags="pci-10ee-0100" key="WONTFIX HW-NO-VNIC-RX-COUNTERS" notes="SN1022 has no counters in VNIC Rx">
           <result value="SKIPPED">
@@ -14126,6 +14346,104 @@
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
+        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.dst_mac.ethertype</arg>
+        <arg name="n_counters"/>
+        <arg name="field_path"/>
+        <notes/>
+        <results tags="pci-10ee-0100" key="WONTFIX HW-NO-VNIC-RX-COUNTERS" notes="SN1022 has no counters in VNIC Rx">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Action is not supported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Action is not supported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.dst_mac.ethertype.ip4</arg>
+        <arg name="n_counters"/>
+        <arg name="field_path"/>
+        <notes/>
+        <results tags="pci-10ee-0100" key="WONTFIX HW-NO-VNIC-RX-COUNTERS" notes="SN1022 has no counters in VNIC Rx">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Action is not supported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Action is not supported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.dst_mac.ip_proto</arg>
+        <arg name="n_counters"/>
+        <arg name="field_path"/>
+        <notes/>
+        <results tags="pci-10ee-0100" key="WONTFIX HW-NO-VNIC-RX-COUNTERS" notes="SN1022 has no counters in VNIC Rx">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Action is not supported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Action is not supported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: L2 and L3 input set are exclusive.</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.dst_mac.ip_proto.udp</arg>
+        <arg name="n_counters"/>
+        <arg name="field_path"/>
+        <notes/>
+        <results tags="pci-10ee-0100" key="WONTFIX HW-NO-VNIC-RX-COUNTERS" notes="SN1022 has no counters in VNIC Rx">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Action is not supported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Action is not supported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
         <arg name="flow_rule_pattern"/>
         <arg name="n_counters"/>
         <arg name="field_path">2.#udp.dst-port.#plain</arg>
@@ -14143,6 +14461,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
           </result>
         </results>
       </iter>
@@ -14165,6 +14488,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
           </result>
         </results>
       </iter>

--- a/trc/filters.xml
+++ b/trc/filters.xml
@@ -15132,12 +15132,12 @@
       <notes/>
       <iter result="PASSED">
         <arg name="env"/>
-        <arg name="ingress">FALSE</arg>
+        <arg name="ingress"/>
         <arg name="promisc"/>
         <arg name="isolated">TRUE</arg>
         <arg name="transfer"/>
         <arg name="flow_rule_pattern"/>
-        <arg name="counter_ids">0,1</arg>
+        <arg name="counter_ids"/>
         <notes/>
         <results tags="pci-10ee-0100" key="WONTFIX HW-ONE-CNT-PER-AR" notes="SN1022 does not support more than one counter per action rule">
           <result value="SKIPPED">
@@ -15167,117 +15167,12 @@
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
-        <arg name="ingress">FALSE</arg>
-        <arg name="promisc"/>
-        <arg name="isolated">TRUE</arg>
-        <arg name="transfer"/>
-        <arg name="flow_rule_pattern"/>
-        <arg name="counter_ids">0,0</arg>
-        <notes/>
-        <results tags="pci-10ee-0100" key="WONTFIX HW-ONE-CNT-PER-AR" notes="SN1022 does not support more than one counter per action rule">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Failed to process the action</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-159b" key="FLOW-ISOLATE" notes="net/ice does not support rte_flow_isolate()">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-      </iter>
-      <iter result="PASSED">
-        <arg name="env"/>
-        <arg name="ingress">TRUE</arg>
-        <arg name="promisc"/>
-        <arg name="isolated">TRUE</arg>
-        <arg name="transfer"/>
-        <arg name="flow_rule_pattern"/>
-        <arg name="counter_ids">0,1</arg>
-        <notes/>
-        <results tags="pci-10ee-0100" key="WONTFIX HW-ONE-CNT-PER-AR" notes="SN1022 does not support more than one counter per action rule">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Failed to process the action</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-159b" key="FLOW-ISOLATE" notes="net/ice does not support rte_flow_isolate()">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-      </iter>
-      <iter result="PASSED">
-        <arg name="env"/>
-        <arg name="ingress">TRUE</arg>
-        <arg name="promisc"/>
-        <arg name="isolated">TRUE</arg>
-        <arg name="transfer"/>
-        <arg name="flow_rule_pattern"/>
-        <arg name="counter_ids">0,0</arg>
-        <notes/>
-        <results tags="pci-10ee-0100" key="WONTFIX HW-ONE-CNT-PER-AR" notes="SN1022 does not support more than one counter per action rule">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Failed to process the action</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-159b" key="FLOW-ISOLATE" notes="net/ice does not support rte_flow_isolate()">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-      </iter>
-      <iter result="PASSED">
-        <arg name="env"/>
-        <arg name="ingress">FALSE</arg>
+        <arg name="ingress"/>
         <arg name="promisc"/>
         <arg name="isolated">FALSE</arg>
         <arg name="transfer"/>
-        <arg name="flow_rule_pattern"/>
-        <arg name="counter_ids">0,1</arg>
+        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.dst_mac</arg>
+        <arg name="counter_ids"/>
         <notes/>
         <results tags="pci-10ee-0100" key="WONTFIX HW-ONE-CNT-PER-AR" notes="SN1022 does not support more than one counter per action rule">
           <result value="SKIPPED">
@@ -15299,15 +15194,20 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-ETH-NO-ETHERTYPE" notes="net/i40e does not support flow pattern item ETH without EtherType">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid type mask.</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
-        <arg name="ingress">FALSE</arg>
+        <arg name="ingress"/>
         <arg name="promisc"/>
         <arg name="isolated">FALSE</arg>
         <arg name="transfer"/>
-        <arg name="flow_rule_pattern"/>
-        <arg name="counter_ids">0,0</arg>
+        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.dst_mac.3tuple.tcp</arg>
+        <arg name="counter_ids"/>
         <notes/>
         <results tags="pci-10ee-0100" key="WONTFIX HW-ONE-CNT-PER-AR" notes="SN1022 does not support more than one counter per action rule">
           <result value="SKIPPED">
@@ -15329,15 +15229,20 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
-        <arg name="ingress">TRUE</arg>
+        <arg name="ingress"/>
         <arg name="promisc"/>
         <arg name="isolated">FALSE</arg>
         <arg name="transfer"/>
-        <arg name="flow_rule_pattern"/>
-        <arg name="counter_ids">0,1</arg>
+        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.dst_mac.5tuple.tcp</arg>
+        <arg name="counter_ids"/>
         <notes/>
         <results tags="pci-10ee-0100" key="WONTFIX HW-ONE-CNT-PER-AR" notes="SN1022 does not support more than one counter per action rule">
           <result value="SKIPPED">
@@ -15359,34 +15264,9 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
-      </iter>
-      <iter result="PASSED">
-        <arg name="env"/>
-        <arg name="ingress">TRUE</arg>
-        <arg name="promisc"/>
-        <arg name="isolated">FALSE</arg>
-        <arg name="transfer"/>
-        <arg name="flow_rule_pattern"/>
-        <arg name="counter_ids">0,0</arg>
-        <notes/>
-        <results tags="pci-10ee-0100" key="WONTFIX HW-ONE-CNT-PER-AR" notes="SN1022 does not support more than one counter per action rule">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Failed to process the action</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
+        <results tags="net_i40e" key="FLOW-PATTERN-L2-L3" notes="net/i40e does not support flow pattern with L2 and L3 together">
           <result value="FAILED">
-            <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
           </result>
         </results>
       </iter>

--- a/trc/filters.xml
+++ b/trc/filters.xml
@@ -14394,6 +14394,11 @@
             <verdict>Flow tunnel offload is unsupported</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-TUNNEL-OFFLOAD" notes="net/i40e does not support flow tunnel offload">
+          <result value="SKIPPED">
+            <verdict>Flow tunnel offload is unsupported</verdict>
+          </result>
+        </results>
       </iter>
     </test>
   </iter>

--- a/trc/filters.xml
+++ b/trc/filters.xml
@@ -2240,6 +2240,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-ETH-NO-ETHERTYPE" notes="net/i40e does not support flow pattern item ETH without EtherType">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid type mask.</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -2261,6 +2266,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-ETH-NO-ETHERTYPE" notes="net/i40e does not support flow pattern item ETH without EtherType">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid type mask.</verdict>
           </result>
         </results>
       </iter>
@@ -4414,6 +4424,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-ETH-NO-ETHERTYPE" notes="net/i40e does not support flow pattern item ETH without EtherType">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid type mask.</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count">FALSE</arg>
@@ -4433,6 +4448,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-ETH-NO-ETHERTYPE" notes="net/i40e does not support flow pattern item ETH without EtherType">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid type mask.</verdict>
           </result>
         </results>
       </iter>
@@ -6141,6 +6161,11 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-ETH-NO-ETHERTYPE" notes="net/i40e does not support flow pattern item ETH without EtherType">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid type mask.</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count"/>
@@ -6857,6 +6882,11 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-ETH-NO-ETHERTYPE" notes="net/i40e does not support flow pattern item ETH without EtherType">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid type mask.</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count"/>
@@ -8492,6 +8522,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-ETH-NO-ETHERTYPE" notes="net/i40e does not support flow pattern item ETH without EtherType">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid type mask.</verdict>
           </result>
         </results>
       </iter>
@@ -13381,6 +13416,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-ETH-NO-ETHERTYPE" notes="net/i40e does not support flow pattern item ETH without EtherType">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid type mask.</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -13499,6 +13539,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-ETH-NO-ETHERTYPE" notes="net/i40e does not support flow pattern item ETH without EtherType">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid type mask.</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -13612,6 +13657,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-ETH-NO-ETHERTYPE" notes="net/i40e does not support flow pattern item ETH without EtherType">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid type mask.</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -13694,6 +13744,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-ETH-NO-ETHERTYPE" notes="net/i40e does not support flow pattern item ETH without EtherType">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid type mask.</verdict>
           </result>
         </results>
       </iter>
@@ -13783,6 +13838,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-ETH-NO-ETHERTYPE" notes="net/i40e does not support flow pattern item ETH without EtherType">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid type mask.</verdict>
           </result>
         </results>
       </iter>
@@ -13986,6 +14046,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-ETH-NO-ETHERTYPE" notes="net/i40e does not support flow pattern item ETH without EtherType">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid type mask.</verdict>
           </result>
         </results>
       </iter>

--- a/trc/filters.xml
+++ b/trc/filters.xml
@@ -1579,6 +1579,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-ETH-DMAC-MASK" notes="net/i40e does not support flow pattern item ETH with destination MAC mask">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid type mask.</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -1615,6 +1620,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-ETH-DMAC-MASK" notes="net/i40e does not support flow pattern item ETH with destination MAC mask">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid MAC_addr mask.</verdict>
           </result>
         </results>
       </iter>
@@ -1655,6 +1665,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-ETH-DMAC-MASK" notes="net/i40e does not support flow pattern item ETH with destination MAC mask">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid MAC_addr mask.</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -1681,6 +1696,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-ETH-DMAC-MASK" notes="net/i40e does not support flow pattern item ETH with destination MAC mask">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid type mask.</verdict>
           </result>
         </results>
       </iter>
@@ -5015,6 +5035,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-ETH-DMAC-MASK" notes="net/i40e does not support flow pattern item ETH with destination MAC mask">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid MAC_addr mask.</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count">FALSE</arg>
@@ -5034,6 +5059,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-ETH-DMAC-MASK" notes="net/i40e does not support flow pattern item ETH with destination MAC mask">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid type mask.</verdict>
           </result>
         </results>
       </iter>
@@ -5072,6 +5102,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-ETH-DMAC-MASK" notes="net/i40e does not support flow pattern item ETH with destination MAC mask">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid MAC_addr mask.</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count">FALSE</arg>
@@ -5091,6 +5126,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-ETH-DMAC-MASK" notes="net/i40e does not support flow pattern item ETH with destination MAC mask">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid type mask.</verdict>
           </result>
         </results>
       </iter>
@@ -6192,6 +6232,11 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-ETH-DMAC-MASK" notes="net/i40e does not support flow pattern item ETH with destination MAC mask">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid MAC_addr mask.</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count"/>
@@ -6216,6 +6261,11 @@
         <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
           <result value="FAILED">
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-ETH-DMAC-MASK" notes="net/i40e does not support flow pattern item ETH with destination MAC mask">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid MAC_addr mask.</verdict>
           </result>
         </results>
       </iter>
@@ -6913,6 +6963,11 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-ETH-DMAC-MASK" notes="net/i40e does not support flow pattern item ETH with destination MAC mask">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid MAC_addr mask.</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count"/>
@@ -6937,6 +6992,11 @@
         <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
           <result value="FAILED">
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-ETH-DMAC-MASK" notes="net/i40e does not support flow pattern item ETH with destination MAC mask">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid MAC_addr mask.</verdict>
           </result>
         </results>
       </iter>
@@ -8555,6 +8615,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-ETH-DMAC-MASK" notes="net/i40e does not support flow pattern item ETH with destination MAC mask">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid MAC_addr mask.</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count">TRUE</arg>
@@ -8579,6 +8644,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-ETH-DMAC-MASK" notes="net/i40e does not support flow pattern item ETH with destination MAC mask">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid MAC_addr mask.</verdict>
           </result>
         </results>
       </iter>

--- a/trc/filters.xml
+++ b/trc/filters.xml
@@ -15096,6 +15096,11 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-VXLAN-NO-INNER-ETH" notes="net/i40e does not support flow pattern wth VXLAN without inner ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
       </iter>
     </test>
     <test name="flow_rule_vlan_push" type="script">

--- a/trc/filters.xml
+++ b/trc/filters.xml
@@ -1746,6 +1746,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-2TAGS" notes="net/i40e does not support flow pattern with 2 VLAN tags">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -1998,6 +2003,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-2TAGS" notes="net/i40e does not support flow pattern with 2 VLAN tags">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
           </result>
         </results>
       </iter>
@@ -5098,6 +5108,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-2TAGS" notes="net/i40e does not support flow pattern with 2 VLAN tags">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count">FALSE</arg>
@@ -5142,6 +5157,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-2TAGS" notes="net/i40e does not support flow pattern with 2 VLAN tags">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
           </result>
         </results>
       </iter>
@@ -6400,6 +6420,11 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-2TAGS" notes="net/i40e does not support flow pattern with 2 VLAN tags">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count"/>
@@ -7196,6 +7221,11 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-2TAGS" notes="net/i40e does not support flow pattern with 2 VLAN tags">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count"/>
@@ -8911,6 +8941,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-2TAGS" notes="net/i40e does not support flow pattern with 2 VLAN tags">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
           </result>
         </results>
       </iter>

--- a/trc/filters.xml
+++ b/trc/filters.xml
@@ -2651,6 +2651,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-PPPOE" notes="net/i40e does not support flow pattern item PPPOE">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -2687,6 +2692,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-PPPOE" notes="net/i40e does not support flow pattern item PPPOE">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
           </result>
         </results>
       </iter>
@@ -2733,6 +2743,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-PPPOE" notes="net/i40e does not support flow pattern item PPPOE">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -2775,6 +2790,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-PPPOE" notes="net/i40e does not support flow pattern item PPPOE">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
           </result>
         </results>
       </iter>
@@ -4555,6 +4575,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-PPPOE" notes="net/i40e does not support flow pattern item PPPOE">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count">FALSE</arg>
@@ -4589,6 +4614,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-PPPOE" notes="net/i40e does not support flow pattern item PPPOE">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
           </result>
         </results>
       </iter>
@@ -4632,6 +4662,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-PPPOE" notes="net/i40e does not support flow pattern item PPPOE">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count">FALSE</arg>
@@ -4671,6 +4706,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-PPPOE" notes="net/i40e does not support flow pattern item PPPOE">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
           </result>
         </results>
       </iter>
@@ -5941,6 +5981,11 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-PPPOE" notes="net/i40e does not support flow pattern item PPPOE">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count"/>
@@ -5975,6 +6020,11 @@
         <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
           <result value="FAILED">
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-PPPOE" notes="net/i40e does not support flow pattern item PPPOE">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
           </result>
         </results>
       </iter>
@@ -6647,6 +6697,11 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-PPPOE" notes="net/i40e does not support flow pattern item PPPOE">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count"/>
@@ -6681,6 +6736,11 @@
         <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
           <result value="FAILED">
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-PPPOE" notes="net/i40e does not support flow pattern item PPPOE">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
           </result>
         </results>
       </iter>
@@ -8279,6 +8339,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-PPPOE" notes="net/i40e does not support flow pattern item PPPOE">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count">TRUE</arg>
@@ -8308,6 +8373,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-PPPOE" notes="net/i40e does not support flow pattern item PPPOE">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
           </result>
         </results>
       </iter>
@@ -13767,13 +13837,155 @@
       </iter>
     </test>
     <test name="flow_rule_counters" type="script">
-      <objective>Check that COUNT actions are carried out correctly</objective>
+      <objective>Make sure that RTE flow API COUNT actions are carried out correctly</objective>
       <notes/>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.ethertype</arg>
+        <arg name="n_counters"/>
+        <arg name="field_path"/>
+        <notes/>
+        <results tags="pci-10ee-0100" key="WONTFIX HW-NO-VNIC-RX-COUNTERS" notes="SN1022 has no counters in VNIC Rx">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Action is not supported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Action is not supported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.ethertype.pppoed</arg>
+        <arg name="n_counters"/>
+        <arg name="field_path"/>
+        <notes/>
+        <results tags="pci-10ee-0100" key="WONTFIX HW-NO-VNIC-RX-COUNTERS" notes="SN1022 has no counters in VNIC Rx">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Action is not supported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Action is not supported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-PPPOE" notes="net/i40e does not support flow pattern item PPPOE">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.ethertype.pppoes</arg>
+        <arg name="n_counters"/>
+        <arg name="field_path"/>
+        <notes/>
+        <results tags="pci-10ee-0100" key="WONTFIX HW-NO-VNIC-RX-COUNTERS" notes="SN1022 has no counters in VNIC Rx">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Action is not supported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Action is not supported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-PPPOE" notes="net/i40e does not support flow pattern item PPPOE">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
+          </result>
+        </results>
+      </iter>
       <iter result="PASSED">
         <arg name="env"/>
         <arg name="flow_rule_pattern"/>
         <arg name="n_counters"/>
-        <arg name="field_path"/>
+        <arg name="field_path">0.#eth.tagged.#tagged.vlan-id.#plain</arg>
+        <notes/>
+        <results tags="pci-10ee-0100" key="WONTFIX HW-NO-VNIC-RX-COUNTERS" notes="SN1022 has no counters in VNIC Rx">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Action is not supported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Action is not supported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="flow_rule_pattern"/>
+        <arg name="n_counters"/>
+        <arg name="field_path">0.#eth.dst-addr.#plain</arg>
+        <notes/>
+        <results tags="pci-10ee-0100" key="WONTFIX HW-NO-VNIC-RX-COUNTERS" notes="SN1022 has no counters in VNIC Rx">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Action is not supported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Action is not supported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="flow_rule_pattern"/>
+        <arg name="n_counters"/>
+        <arg name="field_path">2.#udp.dst-port.#plain</arg>
+        <notes/>
+        <results tags="pci-10ee-0100" key="WONTFIX HW-NO-VNIC-RX-COUNTERS" notes="SN1022 has no counters in VNIC Rx">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Action is not supported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Action is not supported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="flow_rule_pattern"/>
+        <arg name="n_counters"/>
+        <arg name="field_path">2.#tcp.dst-port.#plain</arg>
         <notes/>
         <results tags="pci-10ee-0100" key="WONTFIX HW-NO-VNIC-RX-COUNTERS" notes="SN1022 has no counters in VNIC Rx">
           <result value="SKIPPED">

--- a/trc/filters.xml
+++ b/trc/filters.xml
@@ -12053,6 +12053,11 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-TUNNEL-NO-DMAC" notes="net/i40e requires tunnel filters to have destination MAC matching in both outer and inner headers">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ether spec/mask</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count"/>
@@ -12148,6 +12153,11 @@
         <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
           <result value="FAILED">
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-TUNNEL-NO-DMAC" notes="net/i40e requires tunnel filters to have destination MAC matching in both outer and inner headers">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ether spec/mask</verdict>
           </result>
         </results>
       </iter>
@@ -13103,6 +13113,11 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-TUNNEL-NO-DMAC" notes="net/i40e requires tunnel filters to have destination MAC matching in both outer and inner headers">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ether spec/mask</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count"/>
@@ -13198,6 +13213,11 @@
         <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
           <result value="FAILED">
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-TUNNEL-NO-DMAC" notes="net/i40e requires tunnel filters to have destination MAC matching in both outer and inner headers">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ether spec/mask</verdict>
           </result>
         </results>
       </iter>

--- a/trc/filters.xml
+++ b/trc/filters.xml
@@ -13878,6 +13878,11 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-VLAN-PUSH" notes="net/i40e does not support VLAN push action">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Not supported action.</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -13902,6 +13907,11 @@
         <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
           <result value="FAILED">
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-VLAN-PUSH" notes="net/i40e does not support VLAN push action">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid action.</verdict>
           </result>
         </results>
       </iter>
@@ -13930,6 +13940,11 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-VLAN-PUSH" notes="net/i40e does not support VLAN push action">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid action.</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -13954,6 +13969,11 @@
         <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
           <result value="FAILED">
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-DMAC-ETHERTYPE" notes="net/i40e does not support filtering on destination MAC and EtherType together in FDIR mode">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid input set</verdict>
           </result>
         </results>
       </iter>
@@ -13987,6 +14007,11 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-VLAN-PUSH" notes="net/i40e does not support VLAN push action">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Not supported action.</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -14011,6 +14036,11 @@
         <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
           <result value="FAILED">
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-VLAN-PUSH" notes="net/i40e does not support VLAN push action">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid action.</verdict>
           </result>
         </results>
       </iter>
@@ -14039,6 +14069,11 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-VLAN-PUSH" notes="net/i40e does not support VLAN push action">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid action.</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -14063,6 +14098,11 @@
         <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
           <result value="FAILED">
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-DMAC-ETHERTYPE" notes="net/i40e does not support filtering on destination MAC and EtherType together in FDIR mode">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid input set</verdict>
           </result>
         </results>
       </iter>

--- a/trc/filters.xml
+++ b/trc/filters.xml
@@ -11291,7 +11291,7 @@
       <notes/>
       <iter result="PASSED">
         <arg name="count"/>
-        <arg name="ingress">FALSE</arg>
+        <arg name="ingress"/>
         <arg name="promisc"/>
         <arg name="isolated">TRUE</arg>
         <arg name="transfer"/>
@@ -11322,12 +11322,12 @@
       </iter>
       <iter result="PASSED">
         <arg name="count"/>
-        <arg name="ingress">FALSE</arg>
+        <arg name="ingress"/>
         <arg name="promisc"/>
         <arg name="isolated">FALSE</arg>
         <arg name="transfer"/>
         <arg name="env"/>
-        <arg name="flow_rule_pattern"/>
+        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.3tuple.udp6</arg>
         <arg name="is_ip6_inner_frame"/>
         <notes/>
         <results tags="pci-1924">
@@ -11345,46 +11345,20 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
-      </iter>
-      <iter result="PASSED">
-        <arg name="count"/>
-        <arg name="ingress">TRUE</arg>
-        <arg name="promisc"/>
-        <arg name="isolated">TRUE</arg>
-        <arg name="transfer">TRUE</arg>
-        <arg name="env"/>
-        <arg name="flow_rule_pattern"/>
-        <arg name="is_ip6_inner_frame"/>
-        <notes/>
-        <results tags="pci-1924">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-159b" key="FLOW-ISOLATE" notes="net/ice does not support rte_flow_isolate()">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
           </result>
         </results>
       </iter>
       <iter result="PASSED">
         <arg name="count"/>
-        <arg name="ingress">TRUE</arg>
+        <arg name="ingress"/>
         <arg name="promisc"/>
         <arg name="isolated">FALSE</arg>
-        <arg name="transfer">TRUE</arg>
+        <arg name="transfer"/>
         <arg name="env"/>
-        <arg name="flow_rule_pattern"/>
+        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.5tuple.udp6</arg>
         <arg name="is_ip6_inner_frame"/>
         <notes/>
         <results tags="pci-1924">
@@ -11402,66 +11376,40 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
-      </iter>
-      <iter result="PASSED">
-        <arg name="count">TRUE</arg>
-        <arg name="ingress">TRUE</arg>
-        <arg name="promisc"/>
-        <arg name="isolated">TRUE</arg>
-        <arg name="transfer">FALSE</arg>
-        <arg name="env"/>
-        <arg name="flow_rule_pattern"/>
-        <arg name="is_ip6_inner_frame"/>
-        <notes/>
-        <results tags="pci-10ee-0100" key="WONTFIX HW-NO-VNIC-RX-COUNTERS" notes="SN1022 has no counters in VNIC Rx">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Action is not supported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Action is not supported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-159b" key="FLOW-ISOLATE" notes="net/ice does not support rte_flow_isolate()">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
+        <results tags="net_i40e" key="FLOW-PATTERN-NO-ETH" notes="net/i40e does not support flow pattern without item ETH">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Unsupported pattern</verdict>
           </result>
         </results>
       </iter>
       <iter result="PASSED">
-        <arg name="count">TRUE</arg>
-        <arg name="ingress">TRUE</arg>
+        <arg name="count"/>
+        <arg name="ingress"/>
         <arg name="promisc"/>
         <arg name="isolated">FALSE</arg>
-        <arg name="transfer">FALSE</arg>
+        <arg name="transfer"/>
         <arg name="env"/>
-        <arg name="flow_rule_pattern"/>
+        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.ethertype.ip6</arg>
         <arg name="is_ip6_inner_frame"/>
         <notes/>
-        <results tags="pci-10ee-0100" key="WONTFIX HW-NO-VNIC-RX-COUNTERS" notes="SN1022 has no counters in VNIC Rx">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Action is not supported</verdict>
-          </result>
-        </results>
         <results tags="pci-1924">
           <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Action is not supported</verdict>
+            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
           </result>
         </results>
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-COUNT" notes="net/i40e does not support actioun COUNT">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid action.</verdict>
           </result>
         </results>
       </iter>

--- a/trc/filters.xml
+++ b/trc/filters.xml
@@ -6579,6 +6579,11 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-DMAC" notes="net/i40e does not support flow pattern with destination MAC in L2 case">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid input set</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count"/>
@@ -7410,6 +7415,11 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-DMAC" notes="net/i40e does not support flow pattern with destination MAC in L2 case">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid input set</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count"/>
@@ -9140,6 +9150,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-DMAC" notes="net/i40e does not support flow pattern with destination MAC in L2 case">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid input set</verdict>
           </result>
         </results>
       </iter>
@@ -14060,6 +14075,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-DMAC" notes="net/i40e does not support flow pattern with destination MAC in L2 case">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid input set</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -14079,6 +14099,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-DMAC" notes="net/i40e does not support flow pattern with destination MAC in L2 case">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid input set</verdict>
           </result>
         </results>
       </iter>
@@ -14863,6 +14888,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-DMAC" notes="net/i40e does not support flow pattern with destination MAC in L2 case">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid input set</verdict>
           </result>
         </results>
       </iter>

--- a/trc/filters.xml
+++ b/trc/filters.xml
@@ -14354,6 +14354,11 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-REPRESENTED-PORT" notes="net/i40e does not support represented port action, but diagnostics is strange">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid ETH item</verdict>
+          </result>
+        </results>
       </iter>
     </test>
 

--- a/trc/filters.xml
+++ b/trc/filters.xml
@@ -4040,6 +4040,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-RSS-QUEUES-WITH-PATTERN" notes="net/i40e does not support RSS queues specification when pattern is specified">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: RSS Queues not supported when pattern specified</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -4070,6 +4075,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-RSS-QUEUES-WITH-PATTERN" notes="net/i40e does not support RSS queues specification when pattern is specified">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: RSS Queues not supported when pattern specified</verdict>
           </result>
         </results>
       </iter>
@@ -4131,6 +4141,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-RSS-QUEUES-WITH-PATTERN" notes="net/i40e does not support RSS queues specification when pattern is specified">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: RSS Queues not supported when pattern specified</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -4151,6 +4166,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-RSS-QUEUES-WITH-PATTERN" notes="net/i40e does not support RSS queues specification when pattern is specified">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: RSS Queues not supported when pattern specified</verdict>
           </result>
         </results>
       </iter>

--- a/trc/filters.xml
+++ b/trc/filters.xml
@@ -6495,7 +6495,38 @@
       <iter result="PASSED">
         <arg name="count"/>
         <arg name="ingress">TRUE</arg>
-        <arg name="promisc"/>
+        <arg name="promisc">FALSE</arg>
+        <arg name="isolated">FALSE</arg>
+        <arg name="transfer">TRUE</arg>
+        <arg name="env"/>
+        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.unknown_ucast_dst_mac</arg>
+        <arg name="is_ip6_inner_frame"/>
+        <notes/>
+        <results tags="pci-1924">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-ETH-NO-ETHERTYPE" notes="net/i40e does not support flow pattern item ETH without EtherType">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid type mask.</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="count"/>
+        <arg name="ingress">TRUE</arg>
+        <arg name="promisc">TRUE</arg>
         <arg name="isolated">FALSE</arg>
         <arg name="transfer">TRUE</arg>
         <arg name="env"/>
@@ -6526,7 +6557,38 @@
       <iter result="PASSED">
         <arg name="count"/>
         <arg name="ingress">TRUE</arg>
-        <arg name="promisc"/>
+        <arg name="promisc">FALSE</arg>
+        <arg name="isolated">FALSE</arg>
+        <arg name="transfer">TRUE</arg>
+        <arg name="env"/>
+        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.unknown_mcast_dst_mac</arg>
+        <arg name="is_ip6_inner_frame"/>
+        <notes/>
+        <results tags="pci-1924">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-PATTERN-ETH-NO-ETHERTYPE" notes="net/i40e does not support flow pattern item ETH without EtherType">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid type mask.</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="count"/>
+        <arg name="ingress">TRUE</arg>
+        <arg name="promisc">TRUE</arg>
         <arg name="isolated">FALSE</arg>
         <arg name="transfer">TRUE</arg>
         <arg name="env"/>

--- a/trc/filters.xml
+++ b/trc/filters.xml
@@ -6229,6 +6229,11 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-COUNT" notes="net/i40e does not support actioun COUNT">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid action.</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count"/>
@@ -6258,6 +6263,11 @@
         <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
           <result value="FAILED">
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-COUNT" notes="net/i40e does not support actioun COUNT">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid action.</verdict>
           </result>
         </results>
       </iter>
@@ -6368,6 +6378,11 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-COUNT" notes="net/i40e does not support actioun COUNT">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid action.</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count"/>
@@ -6392,6 +6407,11 @@
         <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
           <result value="FAILED">
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-COUNT" notes="net/i40e does not support actioun COUNT">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid action.</verdict>
           </result>
         </results>
       </iter>
@@ -6570,6 +6590,11 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-COUNT" notes="net/i40e does not support actioun COUNT">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid action.</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count"/>
@@ -6630,6 +6655,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-COUNT" notes="net/i40e does not support actioun COUNT">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid action.</verdict>
           </result>
         </results>
       </iter>
@@ -7030,6 +7060,11 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-COUNT" notes="net/i40e does not support actioun COUNT">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid action.</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count"/>
@@ -7059,6 +7094,11 @@
         <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
           <result value="FAILED">
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-COUNT" notes="net/i40e does not support actioun COUNT">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid action.</verdict>
           </result>
         </results>
       </iter>
@@ -7169,6 +7209,11 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-COUNT" notes="net/i40e does not support actioun COUNT">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid action.</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count"/>
@@ -7193,6 +7238,11 @@
         <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
           <result value="FAILED">
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-COUNT" notes="net/i40e does not support actioun COUNT">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid action.</verdict>
           </result>
         </results>
       </iter>
@@ -7371,6 +7421,11 @@
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-COUNT" notes="net/i40e does not support actioun COUNT">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid action.</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="count"/>
@@ -7431,6 +7486,11 @@
         <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
           <result value="FAILED">
             <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-COUNT" notes="net/i40e does not support actioun COUNT">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid action.</verdict>
           </result>
         </results>
       </iter>
@@ -14555,6 +14615,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-COUNT" notes="net/i40e does not support actioun COUNT">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid action.</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -14631,6 +14696,11 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="FLOW-COUNT" notes="net/i40e does not support actioun COUNT">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid action.</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -14700,6 +14770,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-COUNT" notes="net/i40e does not support actioun COUNT">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid action.</verdict>
           </result>
         </results>
       </iter>

--- a/trc/filters.xml
+++ b/trc/filters.xml
@@ -36,7 +36,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -74,7 +74,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -117,7 +117,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -155,7 +155,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -203,7 +203,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -246,7 +246,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -284,7 +284,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -327,7 +327,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -365,7 +365,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -436,7 +436,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -479,7 +479,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -517,7 +517,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -560,7 +560,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -598,7 +598,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -641,7 +641,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -674,7 +674,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -702,7 +702,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -730,7 +730,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -763,7 +763,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -796,7 +796,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -824,7 +824,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -862,7 +862,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -895,7 +895,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -933,7 +933,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -966,7 +966,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -1009,7 +1009,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -1047,7 +1047,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -1085,7 +1085,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -1123,7 +1123,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -1161,7 +1161,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -1209,7 +1209,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -1257,7 +1257,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -1295,7 +1295,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -1333,7 +1333,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -1371,7 +1371,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -1404,7 +1404,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -1442,7 +1442,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -1475,7 +1475,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -3127,7 +3127,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -3223,7 +3223,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -3304,7 +3304,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -3385,7 +3385,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -3491,7 +3491,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -3602,7 +3602,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -3673,7 +3673,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -3710,7 +3710,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -3804,7 +3804,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -3908,7 +3908,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -3993,7 +3993,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -4094,7 +4094,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -7266,7 +7266,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -7302,7 +7302,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -7343,7 +7343,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -7384,7 +7384,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -7420,7 +7420,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -7456,7 +7456,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -7492,7 +7492,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -7528,7 +7528,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -7564,7 +7564,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -7600,7 +7600,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -7636,7 +7636,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -7672,7 +7672,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -7708,7 +7708,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -7744,7 +7744,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -7780,7 +7780,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -7816,7 +7816,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -7852,7 +7852,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -7888,7 +7888,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -7924,7 +7924,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -7960,7 +7960,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -7996,7 +7996,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -8032,7 +8032,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -8068,7 +8068,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -8104,7 +8104,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -8140,7 +8140,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -8883,7 +8883,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -8919,7 +8919,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -8960,7 +8960,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -9001,7 +9001,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -9032,7 +9032,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -9063,7 +9063,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -9094,7 +9094,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -9125,7 +9125,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -9156,7 +9156,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -9187,7 +9187,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -9218,7 +9218,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -9249,7 +9249,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -9280,7 +9280,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -9316,7 +9316,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -9347,7 +9347,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -9378,7 +9378,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -9409,7 +9409,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -9440,7 +9440,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -9471,7 +9471,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -9502,7 +9502,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -9533,7 +9533,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -9564,7 +9564,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -9595,7 +9595,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -9626,7 +9626,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -9657,7 +9657,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -9688,7 +9688,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -9719,7 +9719,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -9755,7 +9755,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -9796,7 +9796,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -9837,7 +9837,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -9868,7 +9868,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -9899,7 +9899,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -9930,7 +9930,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -9961,7 +9961,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -9992,7 +9992,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -10023,7 +10023,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -10054,7 +10054,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -10085,7 +10085,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -10116,7 +10116,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -10152,7 +10152,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -10183,7 +10183,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -10214,7 +10214,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -10245,7 +10245,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -10276,7 +10276,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -10307,7 +10307,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -10338,7 +10338,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -10369,7 +10369,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -10400,7 +10400,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -10431,7 +10431,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -10462,7 +10462,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -10493,7 +10493,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -10524,7 +10524,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -10559,7 +10559,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -10744,7 +10744,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -10866,7 +10866,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -10963,7 +10963,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -11045,7 +11045,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -11157,7 +11157,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -11274,7 +11274,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -11371,7 +11371,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -11458,7 +11458,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -11560,7 +11560,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -11667,7 +11667,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -11779,7 +11779,7 @@
             <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -11796,1118 +11796,6 @@
         <arg name="promisc"/>
         <arg name="isolated">FALSE</arg>
         <arg name="transfer"/>
-        <arg name="env"/>
-        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.dst_mac.vsid.ifrm_dst_mac.nvgre</arg>
-        <arg name="is_ip6_inner_frame"/>
-        <notes/>
-        <results tags="pci-10ee-0100" key="WONTFIX HW-NO-OR-MAC-MATCH" notes="SN1022 has no MAC addresses match in outer rules">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Inconsistent pattern (outer)</verdict>
-          </result>
-        </results>
-        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
-          <result value="FAILED">
-            <verdict>Failed to add a tunnel UDP port</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
-          <result value="FAILED">
-            <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
-          </result>
-        </results>
-      </iter>
-      <iter result="PASSED">
-        <arg name="count"/>
-        <arg name="ingress">TRUE</arg>
-        <arg name="promisc"/>
-        <arg name="isolated">TRUE</arg>
-        <arg name="transfer">TRUE</arg>
-        <arg name="env"/>
-        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.vsid.vxlan</arg>
-        <arg name="is_ip6_inner_frame"/>
-        <notes/>
-        <results tags="vdev-failsafe">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-1521">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-10ee-0100" key="WONTFIX HW-OR-NEED-ETHERTYPE-IP-PROTO-UDP-DST" notes="SN1022 requires EtherType, IP proto (UDP) and UDP destination port in outer rules">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Inconsistent pattern (outer)</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924-0903|pci-1924-1903|pci-1924-0923|pci-1924-1923|((rx-low-latency|rx-packed-stream|rx-dpdk)&amp;(pci-1924-0a03|pci-1924-0b03))">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
-          <result value="FAILED">
-            <verdict>Failed to add a tunnel UDP port</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-159b" key="FLOW-ISOLATE" notes="net/ice does not support rte_flow_isolate()">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-      </iter>
-      <iter result="PASSED">
-        <arg name="count"/>
-        <arg name="ingress">TRUE</arg>
-        <arg name="promisc"/>
-        <arg name="isolated">FALSE</arg>
-        <arg name="transfer">TRUE</arg>
-        <arg name="env"/>
-        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.vsid.vxlan</arg>
-        <arg name="is_ip6_inner_frame"/>
-        <notes/>
-        <results tags="vdev-failsafe">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-10ee-0100" key="WONTFIX HW-OR-NEED-ETHERTYPE-IP-PROTO-UDP-DST" notes="SN1022 requires EtherType, IP proto (UDP) and UDP destination port in outer rules">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Inconsistent pattern (outer)</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-1521">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924-0903|pci-1924-1903|pci-1924-0923|pci-1924-1923|((rx-low-latency|rx-packed-stream|rx-dpdk)&amp;(pci-1924-0a03|pci-1924-0b03))">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
-          <result value="FAILED">
-            <verdict>Failed to add a tunnel UDP port</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
-          <result value="FAILED">
-            <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
-          </result>
-        </results>
-      </iter>
-      <iter result="PASSED">
-        <arg name="count"/>
-        <arg name="ingress">TRUE</arg>
-        <arg name="promisc"/>
-        <arg name="isolated">TRUE</arg>
-        <arg name="transfer">TRUE</arg>
-        <arg name="env"/>
-        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.ip4.udp_dst.vsid.vxlan</arg>
-        <arg name="is_ip6_inner_frame"/>
-        <notes/>
-        <results tags="vdev-failsafe">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924-0903|pci-1924-1903|pci-1924-0923|pci-1924-1923|((rx-low-latency|rx-packed-stream|rx-dpdk)&amp;(pci-1924-0a03|pci-1924-0b03))">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
-          <result value="FAILED">
-            <verdict>Failed to add a tunnel UDP port</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
-          <result value="FAILED">
-            <verdict>Failed to add a tunnel UDP port</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-1521">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-159b" key="FLOW-ISOLATE" notes="net/ice does not support rte_flow_isolate()">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-      </iter>
-      <iter result="PASSED">
-        <arg name="count"/>
-        <arg name="ingress">TRUE</arg>
-        <arg name="promisc"/>
-        <arg name="isolated">FALSE</arg>
-        <arg name="transfer">TRUE</arg>
-        <arg name="env"/>
-        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.ip4.udp_dst.vsid.vxlan</arg>
-        <arg name="is_ip6_inner_frame"/>
-        <notes/>
-        <results tags="vdev-failsafe">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924-0903|pci-1924-1903|pci-1924-0923|pci-1924-1923|((rx-low-latency|rx-packed-stream|rx-dpdk)&amp;(pci-1924-0a03|pci-1924-0b03))">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
-          <result value="FAILED">
-            <verdict>Failed to add a tunnel UDP port</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
-          <result value="FAILED">
-            <verdict>Failed to add a tunnel UDP port</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-1521">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
-          <result value="FAILED">
-            <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
-          </result>
-        </results>
-      </iter>
-      <iter result="PASSED">
-        <arg name="count"/>
-        <arg name="ingress">TRUE</arg>
-        <arg name="promisc"/>
-        <arg name="isolated">TRUE</arg>
-        <arg name="transfer">TRUE</arg>
-        <arg name="env"/>
-        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.ip6.udp_dst.vsid.vxlan</arg>
-        <arg name="is_ip6_inner_frame"/>
-        <notes/>
-        <results tags="vdev-failsafe">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924-0903|pci-1924-1903|pci-1924-0923|pci-1924-1923|((rx-low-latency|rx-packed-stream|rx-dpdk)&amp;(pci-1924-0a03|pci-1924-0b03))">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
-          <result value="FAILED">
-            <verdict>Failed to add a tunnel UDP port</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-1521">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-159b" key="FLOW-ISOLATE" notes="net/ice does not support rte_flow_isolate()">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-      </iter>
-      <iter result="PASSED">
-        <arg name="count"/>
-        <arg name="ingress">TRUE</arg>
-        <arg name="promisc"/>
-        <arg name="isolated">FALSE</arg>
-        <arg name="transfer">TRUE</arg>
-        <arg name="env"/>
-        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.ip6.udp_dst.vsid.vxlan</arg>
-        <arg name="is_ip6_inner_frame"/>
-        <notes/>
-        <results tags="vdev-failsafe">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924-0903|pci-1924-1903|pci-1924-0923|pci-1924-1923|((rx-low-latency|rx-packed-stream|rx-dpdk)&amp;(pci-1924-0a03|pci-1924-0b03))">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
-          <result value="FAILED">
-            <verdict>Failed to add a tunnel UDP port</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-1521">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
-          <result value="FAILED">
-            <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
-          </result>
-        </results>
-      </iter>
-      <iter result="PASSED">
-        <arg name="count"/>
-        <arg name="ingress">TRUE</arg>
-        <arg name="promisc"/>
-        <arg name="isolated">TRUE</arg>
-        <arg name="transfer">TRUE</arg>
-        <arg name="env"/>
-        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.vsid.ifrm_dst_mac.vxlan</arg>
-        <arg name="is_ip6_inner_frame"/>
-        <notes/>
-        <results tags="vdev-failsafe">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-1521">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-10ee-0100" key="WONTFIX HW-OR-NEED-ETHERTYPE-IP-PROTO-UDP-DST" notes="SN1022 requires EtherType, IP proto (UDP) and UDP destination port in outer rules">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Inconsistent pattern (outer)</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924-0903|pci-1924-1903|pci-1924-0923|pci-1924-1923|((rx-low-latency|rx-packed-stream|rx-dpdk)&amp;(pci-1924-0a03|pci-1924-0b03))">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
-          <result value="FAILED">
-            <verdict>Failed to add a tunnel UDP port</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-159b" key="FLOW-ISOLATE" notes="net/ice does not support rte_flow_isolate()">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-      </iter>
-      <iter result="PASSED">
-        <arg name="count"/>
-        <arg name="ingress">TRUE</arg>
-        <arg name="promisc"/>
-        <arg name="isolated">FALSE</arg>
-        <arg name="transfer">TRUE</arg>
-        <arg name="env"/>
-        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.vsid.ifrm_dst_mac.vxlan</arg>
-        <arg name="is_ip6_inner_frame"/>
-        <notes/>
-        <results tags="vdev-failsafe">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-1521">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-10ee-0100" key="WONTFIX HW-OR-NEED-ETHERTYPE-IP-PROTO-UDP-DST" notes="SN1022 requires EtherType, IP proto (UDP) and UDP destination port in outer rules">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Inconsistent pattern (outer)</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924-0903|pci-1924-1903|pci-1924-0923|pci-1924-1923|((rx-low-latency|rx-packed-stream|rx-dpdk)&amp;(pci-1924-0a03|pci-1924-0b03))">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
-          <result value="FAILED">
-            <verdict>Failed to add a tunnel UDP port</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
-          <result value="FAILED">
-            <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
-          </result>
-        </results>
-      </iter>
-      <iter result="PASSED">
-        <arg name="count"/>
-        <arg name="ingress">TRUE</arg>
-        <arg name="promisc"/>
-        <arg name="isolated">TRUE</arg>
-        <arg name="transfer">TRUE</arg>
-        <arg name="env"/>
-        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.ip4.udp_dst.vsid.ifrm_dst_mac.vxlan</arg>
-        <arg name="is_ip6_inner_frame"/>
-        <notes/>
-        <results tags="vdev-failsafe">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924-0903|pci-1924-1903|pci-1924-0923|pci-1924-1923|((rx-low-latency|rx-packed-stream|rx-dpdk)&amp;(pci-1924-0a03|pci-1924-0b03))">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
-          <result value="FAILED">
-            <verdict>Failed to add a tunnel UDP port</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-1521">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-159b" key="FLOW-ISOLATE" notes="net/ice does not support rte_flow_isolate()">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-      </iter>
-      <iter result="PASSED">
-        <arg name="count"/>
-        <arg name="ingress">TRUE</arg>
-        <arg name="promisc"/>
-        <arg name="isolated">FALSE</arg>
-        <arg name="transfer">TRUE</arg>
-        <arg name="env"/>
-        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.ip4.udp_dst.vsid.ifrm_dst_mac.vxlan</arg>
-        <arg name="is_ip6_inner_frame"/>
-        <notes/>
-        <results tags="vdev-failsafe">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924-0903|pci-1924-1903|pci-1924-0923|pci-1924-1923|((rx-low-latency|rx-packed-stream|rx-dpdk)&amp;(pci-1924-0a03|pci-1924-0b03))">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
-          <result value="FAILED">
-            <verdict>Failed to add a tunnel UDP port</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-1521">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
-          <result value="FAILED">
-            <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
-          </result>
-        </results>
-      </iter>
-      <iter result="PASSED">
-        <arg name="count"/>
-        <arg name="ingress">TRUE</arg>
-        <arg name="promisc"/>
-        <arg name="isolated">TRUE</arg>
-        <arg name="transfer">TRUE</arg>
-        <arg name="env"/>
-        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.ip6.udp_dst.vsid.ifrm_dst_mac.vxlan</arg>
-        <arg name="is_ip6_inner_frame"/>
-        <notes/>
-        <results tags="vdev-failsafe">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924-0903|pci-1924-1903|pci-1924-0923|pci-1924-1923|((rx-low-latency|rx-packed-stream|rx-dpdk)&amp;(pci-1924-0a03|pci-1924-0b03))">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
-          <result value="FAILED">
-            <verdict>Failed to add a tunnel UDP port</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-1521">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-159b" key="FLOW-ISOLATE" notes="net/ice does not support rte_flow_isolate()">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-      </iter>
-      <iter result="PASSED">
-        <arg name="count"/>
-        <arg name="ingress">TRUE</arg>
-        <arg name="promisc"/>
-        <arg name="isolated">FALSE</arg>
-        <arg name="transfer">TRUE</arg>
-        <arg name="env"/>
-        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.ip6.udp_dst.vsid.ifrm_dst_mac.vxlan</arg>
-        <arg name="is_ip6_inner_frame"/>
-        <notes/>
-        <results tags="vdev-failsafe">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924-0903|pci-1924-1903|pci-1924-0923|pci-1924-1923|((rx-low-latency|rx-packed-stream|rx-dpdk)&amp;(pci-1924-0a03|pci-1924-0b03))">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
-          <result value="FAILED">
-            <verdict>Failed to add a tunnel UDP port</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-1521">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
-          <result value="FAILED">
-            <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
-          </result>
-        </results>
-      </iter>
-      <iter result="PASSED">
-        <arg name="count"/>
-        <arg name="ingress">TRUE</arg>
-        <arg name="promisc"/>
-        <arg name="isolated">TRUE</arg>
-        <arg name="transfer">TRUE</arg>
-        <arg name="env"/>
-        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.dst_mac.vsid.ifrm_dst_mac.vxlan</arg>
-        <arg name="is_ip6_inner_frame"/>
-        <notes/>
-        <results tags="vdev-failsafe">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-10ee-0100" key="WONTFIX HW-NO-OR-MAC-MATCH" notes="SN1022 has no MAC addresses match in outer rules">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Inconsistent pattern (outer)</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-1521">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924-0903|pci-1924-1903|pci-1924-0923|pci-1924-1923|((rx-low-latency|rx-packed-stream|rx-dpdk)&amp;(pci-1924-0a03|pci-1924-0b03))">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
-          <result value="FAILED">
-            <verdict>Failed to add a tunnel UDP port</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-159b" key="FLOW-ISOLATE" notes="net/ice does not support rte_flow_isolate()">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-      </iter>
-      <iter result="PASSED">
-        <arg name="count"/>
-        <arg name="ingress">TRUE</arg>
-        <arg name="promisc"/>
-        <arg name="isolated">FALSE</arg>
-        <arg name="transfer">TRUE</arg>
-        <arg name="env"/>
-        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.dst_mac.vsid.ifrm_dst_mac.vxlan</arg>
-        <arg name="is_ip6_inner_frame"/>
-        <notes/>
-        <results tags="vdev-failsafe">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-10ee-0100" key="WONTFIX HW-NO-OR-MAC-MATCH" notes="SN1022 has no MAC addresses match in outer rules">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Inconsistent pattern (outer)</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-1521">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924-0903|pci-1924-1903|pci-1924-0923|pci-1924-1923|((rx-low-latency|rx-packed-stream|rx-dpdk)&amp;(pci-1924-0a03|pci-1924-0b03))">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
-          <result value="FAILED">
-            <verdict>Failed to add a tunnel UDP port</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
-          <result value="FAILED">
-            <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
-          </result>
-        </results>
-      </iter>
-      <iter result="PASSED">
-        <arg name="count"/>
-        <arg name="ingress">TRUE</arg>
-        <arg name="promisc"/>
-        <arg name="isolated">TRUE</arg>
-        <arg name="transfer">TRUE</arg>
-        <arg name="env"/>
-        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.dst_mac.vsid.ifrm_dst_mac.vxlan6</arg>
-        <arg name="is_ip6_inner_frame"/>
-        <notes/>
-        <results tags="vdev-failsafe">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-10ee-0100" key="WONTFIX HW-NO-OR-MAC-MATCH" notes="SN1022 has no MAC addresses match in outer rules">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Inconsistent pattern (outer)</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-1521">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924-0903|pci-1924-1903|pci-1924-0923|pci-1924-1923|((rx-low-latency|rx-packed-stream|rx-dpdk)&amp;(pci-1924-0a03|pci-1924-0b03))">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
-          <result value="FAILED">
-            <verdict>Failed to add a tunnel UDP port</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-159b" key="FLOW-ISOLATE" notes="net/ice does not support rte_flow_isolate()">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-      </iter>
-      <iter result="PASSED">
-        <arg name="count"/>
-        <arg name="ingress">TRUE</arg>
-        <arg name="promisc"/>
-        <arg name="isolated">FALSE</arg>
-        <arg name="transfer">TRUE</arg>
-        <arg name="env"/>
-        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.dst_mac.vsid.ifrm_dst_mac.vxlan6</arg>
-        <arg name="is_ip6_inner_frame"/>
-        <notes/>
-        <results tags="vdev-failsafe">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-10ee-0100" key="WONTFIX HW-NO-OR-MAC-MATCH" notes="SN1022 has no MAC addresses match in outer rules">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Inconsistent pattern (outer)</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-1521">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924-0903|pci-1924-1903|pci-1924-0923|pci-1924-1923|((rx-low-latency|rx-packed-stream|rx-dpdk)&amp;(pci-1924-0a03|pci-1924-0b03))">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
-          <result value="FAILED">
-            <verdict>Failed to add a tunnel UDP port</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
-          <result value="FAILED">
-            <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
-          </result>
-        </results>
-      </iter>
-      <iter result="PASSED">
-        <arg name="count"/>
-        <arg name="ingress">TRUE</arg>
-        <arg name="promisc"/>
-        <arg name="isolated">TRUE</arg>
-        <arg name="transfer">TRUE</arg>
-        <arg name="env"/>
-        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.dst_mac.vsid.ifrm_dst_mac.geneve</arg>
-        <arg name="is_ip6_inner_frame"/>
-        <notes/>
-        <results tags="vdev-failsafe">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-1521">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-10ee-0100" key="WONTFIX HW-GENEVE" notes="SN1022 does not support GENEVE">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924-0903|pci-1924-1903|pci-1924-0923|pci-1924-1923|((rx-low-latency|rx-packed-stream|rx-dpdk)&amp;(pci-1924-0a03|pci-1924-0b03))">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
-          <result value="FAILED">
-            <verdict>Failed to add a tunnel UDP port</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-159b" key="FLOW-ISOLATE" notes="net/ice does not support rte_flow_isolate()">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-      </iter>
-      <iter result="PASSED">
-        <arg name="count"/>
-        <arg name="ingress">TRUE</arg>
-        <arg name="promisc"/>
-        <arg name="isolated">FALSE</arg>
-        <arg name="transfer">TRUE</arg>
-        <arg name="env"/>
-        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.dst_mac.vsid.ifrm_dst_mac.geneve</arg>
-        <arg name="is_ip6_inner_frame"/>
-        <notes/>
-        <results tags="vdev-failsafe">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-1521">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-10ee-0100" key="WONTFIX HW-GENEVE" notes="SN1022 does not support GENEVE">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924-0903|pci-1924-1903|pci-1924-0923|pci-1924-1923|((rx-low-latency|rx-packed-stream|rx-dpdk)&amp;(pci-1924-0a03|pci-1924-0b03))">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
-          <result value="FAILED">
-            <verdict>Failed to add a tunnel UDP port</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-159b" key="NO-GENEVE" notes="ice does not support GENEVE tunnels">
-          <result value="SKIPPED">
-            <verdict>The tunnel type is unsupported</verdict>
-          </result>
-        </results>
-      </iter>
-      <iter result="PASSED">
-        <arg name="count"/>
-        <arg name="ingress">TRUE</arg>
-        <arg name="promisc"/>
-        <arg name="isolated">TRUE</arg>
-        <arg name="transfer">TRUE</arg>
-        <arg name="env"/>
-        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.dst_mac.vsid.ifrm_dst_mac.geneve6</arg>
-        <arg name="is_ip6_inner_frame"/>
-        <notes/>
-        <results tags="vdev-failsafe">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-1521">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-10ee-0100" key="WONTFIX HW-GENEVE" notes="SN1022 does not support GENEVE">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924-0903|pci-1924-1903|pci-1924-0923|pci-1924-1923|((rx-low-latency|rx-packed-stream|rx-dpdk)&amp;(pci-1924-0a03|pci-1924-0b03))">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
-          <result value="FAILED">
-            <verdict>Failed to add a tunnel UDP port</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-159b" key="FLOW-ISOLATE" notes="net/ice does not support rte_flow_isolate()">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-      </iter>
-      <iter result="PASSED">
-        <arg name="count"/>
-        <arg name="ingress">TRUE</arg>
-        <arg name="promisc"/>
-        <arg name="isolated">FALSE</arg>
-        <arg name="transfer">TRUE</arg>
-        <arg name="env"/>
-        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.dst_mac.vsid.ifrm_dst_mac.geneve6</arg>
-        <arg name="is_ip6_inner_frame"/>
-        <notes/>
-        <results tags="vdev-failsafe">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-1521">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-10ee-0100" key="WONTFIX HW-GENEVE" notes="SN1022 does not support GENEVE">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924-0903|pci-1924-1903|pci-1924-0923|pci-1924-1923|((rx-low-latency|rx-packed-stream|rx-dpdk)&amp;(pci-1924-0a03|pci-1924-0b03))">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041">
-          <result value="SKIPPED">
-            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
-          <result value="FAILED">
-            <verdict>Failed to add a tunnel UDP port</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-159b" key="NO-GENEVE" notes="ice does not support GENEVE tunnels">
-          <result value="SKIPPED">
-            <verdict>The tunnel type is unsupported</verdict>
-          </result>
-        </results>
-      </iter>
-      <iter result="PASSED">
-        <arg name="count"/>
-        <arg name="ingress">TRUE</arg>
-        <arg name="promisc"/>
-        <arg name="isolated">TRUE</arg>
-        <arg name="transfer">TRUE</arg>
-        <arg name="env"/>
-        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.dst_mac.vsid.ifrm_dst_mac.nvgre</arg>
-        <arg name="is_ip6_inner_frame"/>
-        <notes/>
-        <results tags="pci-10ee-0100" key="WONTFIX HW-NO-OR-MAC-MATCH" notes="SN1022 has no MAC addresses match in outer rules">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Inconsistent pattern (outer)</verdict>
-          </result>
-        </results>
-        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-        <results tags="pci-1924">
-          <result value="SKIPPED">
-            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-        <results tags="pci-8086-159b" key="FLOW-ISOLATE" notes="net/ice does not support rte_flow_isolate()">
-          <result value="SKIPPED">
-            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
-          </result>
-        </results>
-      </iter>
-      <iter result="PASSED">
-        <arg name="count"/>
-        <arg name="ingress">TRUE</arg>
-        <arg name="promisc"/>
-        <arg name="isolated">FALSE</arg>
-        <arg name="transfer">TRUE</arg>
         <arg name="env"/>
         <arg name="flow_rule_pattern">VAR.flow_rule_pattern.dst_mac.vsid.ifrm_dst_mac.nvgre</arg>
         <arg name="is_ip6_inner_frame"/>
@@ -12922,6 +11810,1118 @@
             <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
           </result>
         </results>
+        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
+          <result value="FAILED">
+            <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="count"/>
+        <arg name="ingress">TRUE</arg>
+        <arg name="promisc"/>
+        <arg name="isolated">TRUE</arg>
+        <arg name="transfer">TRUE</arg>
+        <arg name="env"/>
+        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.vsid.vxlan</arg>
+        <arg name="is_ip6_inner_frame"/>
+        <notes/>
+        <results tags="vdev-failsafe">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-1521">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-10ee-0100" key="WONTFIX HW-OR-NEED-ETHERTYPE-IP-PROTO-UDP-DST" notes="SN1022 requires EtherType, IP proto (UDP) and UDP destination port in outer rules">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Inconsistent pattern (outer)</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924-0903|pci-1924-1903|pci-1924-0923|pci-1924-1923|((rx-low-latency|rx-packed-stream|rx-dpdk)&amp;(pci-1924-0a03|pci-1924-0b03))">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
+          <result value="SKIPPED">
+            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
+          <result value="FAILED">
+            <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+          <result value="SKIPPED">
+            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-159b" key="FLOW-ISOLATE" notes="net/ice does not support rte_flow_isolate()">
+          <result value="SKIPPED">
+            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="count"/>
+        <arg name="ingress">TRUE</arg>
+        <arg name="promisc"/>
+        <arg name="isolated">FALSE</arg>
+        <arg name="transfer">TRUE</arg>
+        <arg name="env"/>
+        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.vsid.vxlan</arg>
+        <arg name="is_ip6_inner_frame"/>
+        <notes/>
+        <results tags="vdev-failsafe">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-10ee-0100" key="WONTFIX HW-OR-NEED-ETHERTYPE-IP-PROTO-UDP-DST" notes="SN1022 requires EtherType, IP proto (UDP) and UDP destination port in outer rules">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Inconsistent pattern (outer)</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-1521">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924-0903|pci-1924-1903|pci-1924-0923|pci-1924-1923|((rx-low-latency|rx-packed-stream|rx-dpdk)&amp;(pci-1924-0a03|pci-1924-0b03))">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
+          <result value="FAILED">
+            <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="count"/>
+        <arg name="ingress">TRUE</arg>
+        <arg name="promisc"/>
+        <arg name="isolated">TRUE</arg>
+        <arg name="transfer">TRUE</arg>
+        <arg name="env"/>
+        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.ip4.udp_dst.vsid.vxlan</arg>
+        <arg name="is_ip6_inner_frame"/>
+        <notes/>
+        <results tags="vdev-failsafe">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924-0903|pci-1924-1903|pci-1924-0923|pci-1924-1923|((rx-low-latency|rx-packed-stream|rx-dpdk)&amp;(pci-1924-0a03|pci-1924-0b03))">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
+          <result value="FAILED">
+            <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
+          <result value="FAILED">
+            <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
+          <result value="SKIPPED">
+            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-1521">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+          <result value="SKIPPED">
+            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-159b" key="FLOW-ISOLATE" notes="net/ice does not support rte_flow_isolate()">
+          <result value="SKIPPED">
+            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="count"/>
+        <arg name="ingress">TRUE</arg>
+        <arg name="promisc"/>
+        <arg name="isolated">FALSE</arg>
+        <arg name="transfer">TRUE</arg>
+        <arg name="env"/>
+        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.ip4.udp_dst.vsid.vxlan</arg>
+        <arg name="is_ip6_inner_frame"/>
+        <notes/>
+        <results tags="vdev-failsafe">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924-0903|pci-1924-1903|pci-1924-0923|pci-1924-1923|((rx-low-latency|rx-packed-stream|rx-dpdk)&amp;(pci-1924-0a03|pci-1924-0b03))">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
+          <result value="FAILED">
+            <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
+          <result value="FAILED">
+            <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-1521">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="count"/>
+        <arg name="ingress">TRUE</arg>
+        <arg name="promisc"/>
+        <arg name="isolated">TRUE</arg>
+        <arg name="transfer">TRUE</arg>
+        <arg name="env"/>
+        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.ip6.udp_dst.vsid.vxlan</arg>
+        <arg name="is_ip6_inner_frame"/>
+        <notes/>
+        <results tags="vdev-failsafe">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924-0903|pci-1924-1903|pci-1924-0923|pci-1924-1923|((rx-low-latency|rx-packed-stream|rx-dpdk)&amp;(pci-1924-0a03|pci-1924-0b03))">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
+          <result value="FAILED">
+            <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
+          <result value="SKIPPED">
+            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-1521">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+          <result value="SKIPPED">
+            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-159b" key="FLOW-ISOLATE" notes="net/ice does not support rte_flow_isolate()">
+          <result value="SKIPPED">
+            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="count"/>
+        <arg name="ingress">TRUE</arg>
+        <arg name="promisc"/>
+        <arg name="isolated">FALSE</arg>
+        <arg name="transfer">TRUE</arg>
+        <arg name="env"/>
+        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.ip6.udp_dst.vsid.vxlan</arg>
+        <arg name="is_ip6_inner_frame"/>
+        <notes/>
+        <results tags="vdev-failsafe">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924-0903|pci-1924-1903|pci-1924-0923|pci-1924-1923|((rx-low-latency|rx-packed-stream|rx-dpdk)&amp;(pci-1924-0a03|pci-1924-0b03))">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
+          <result value="FAILED">
+            <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-1521">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="count"/>
+        <arg name="ingress">TRUE</arg>
+        <arg name="promisc"/>
+        <arg name="isolated">TRUE</arg>
+        <arg name="transfer">TRUE</arg>
+        <arg name="env"/>
+        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.vsid.ifrm_dst_mac.vxlan</arg>
+        <arg name="is_ip6_inner_frame"/>
+        <notes/>
+        <results tags="vdev-failsafe">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-1521">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-10ee-0100" key="WONTFIX HW-OR-NEED-ETHERTYPE-IP-PROTO-UDP-DST" notes="SN1022 requires EtherType, IP proto (UDP) and UDP destination port in outer rules">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Inconsistent pattern (outer)</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924-0903|pci-1924-1903|pci-1924-0923|pci-1924-1923|((rx-low-latency|rx-packed-stream|rx-dpdk)&amp;(pci-1924-0a03|pci-1924-0b03))">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
+          <result value="SKIPPED">
+            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
+          <result value="FAILED">
+            <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+          <result value="SKIPPED">
+            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-159b" key="FLOW-ISOLATE" notes="net/ice does not support rte_flow_isolate()">
+          <result value="SKIPPED">
+            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="count"/>
+        <arg name="ingress">TRUE</arg>
+        <arg name="promisc"/>
+        <arg name="isolated">FALSE</arg>
+        <arg name="transfer">TRUE</arg>
+        <arg name="env"/>
+        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.vsid.ifrm_dst_mac.vxlan</arg>
+        <arg name="is_ip6_inner_frame"/>
+        <notes/>
+        <results tags="vdev-failsafe">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-1521">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-10ee-0100" key="WONTFIX HW-OR-NEED-ETHERTYPE-IP-PROTO-UDP-DST" notes="SN1022 requires EtherType, IP proto (UDP) and UDP destination port in outer rules">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Inconsistent pattern (outer)</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924-0903|pci-1924-1903|pci-1924-0923|pci-1924-1923|((rx-low-latency|rx-packed-stream|rx-dpdk)&amp;(pci-1924-0a03|pci-1924-0b03))">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
+          <result value="FAILED">
+            <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="count"/>
+        <arg name="ingress">TRUE</arg>
+        <arg name="promisc"/>
+        <arg name="isolated">TRUE</arg>
+        <arg name="transfer">TRUE</arg>
+        <arg name="env"/>
+        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.ip4.udp_dst.vsid.ifrm_dst_mac.vxlan</arg>
+        <arg name="is_ip6_inner_frame"/>
+        <notes/>
+        <results tags="vdev-failsafe">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924-0903|pci-1924-1903|pci-1924-0923|pci-1924-1923|((rx-low-latency|rx-packed-stream|rx-dpdk)&amp;(pci-1924-0a03|pci-1924-0b03))">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
+          <result value="FAILED">
+            <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
+          <result value="SKIPPED">
+            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-1521">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+          <result value="SKIPPED">
+            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-159b" key="FLOW-ISOLATE" notes="net/ice does not support rte_flow_isolate()">
+          <result value="SKIPPED">
+            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="count"/>
+        <arg name="ingress">TRUE</arg>
+        <arg name="promisc"/>
+        <arg name="isolated">FALSE</arg>
+        <arg name="transfer">TRUE</arg>
+        <arg name="env"/>
+        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.ip4.udp_dst.vsid.ifrm_dst_mac.vxlan</arg>
+        <arg name="is_ip6_inner_frame"/>
+        <notes/>
+        <results tags="vdev-failsafe">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924-0903|pci-1924-1903|pci-1924-0923|pci-1924-1923|((rx-low-latency|rx-packed-stream|rx-dpdk)&amp;(pci-1924-0a03|pci-1924-0b03))">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
+          <result value="FAILED">
+            <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-1521">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="count"/>
+        <arg name="ingress">TRUE</arg>
+        <arg name="promisc"/>
+        <arg name="isolated">TRUE</arg>
+        <arg name="transfer">TRUE</arg>
+        <arg name="env"/>
+        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.ip6.udp_dst.vsid.ifrm_dst_mac.vxlan</arg>
+        <arg name="is_ip6_inner_frame"/>
+        <notes/>
+        <results tags="vdev-failsafe">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924-0903|pci-1924-1903|pci-1924-0923|pci-1924-1923|((rx-low-latency|rx-packed-stream|rx-dpdk)&amp;(pci-1924-0a03|pci-1924-0b03))">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
+          <result value="FAILED">
+            <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
+          <result value="SKIPPED">
+            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-1521">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+          <result value="SKIPPED">
+            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-159b" key="FLOW-ISOLATE" notes="net/ice does not support rte_flow_isolate()">
+          <result value="SKIPPED">
+            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="count"/>
+        <arg name="ingress">TRUE</arg>
+        <arg name="promisc"/>
+        <arg name="isolated">FALSE</arg>
+        <arg name="transfer">TRUE</arg>
+        <arg name="env"/>
+        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.ip6.udp_dst.vsid.ifrm_dst_mac.vxlan</arg>
+        <arg name="is_ip6_inner_frame"/>
+        <notes/>
+        <results tags="vdev-failsafe">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924-0903|pci-1924-1903|pci-1924-0923|pci-1924-1923|((rx-low-latency|rx-packed-stream|rx-dpdk)&amp;(pci-1924-0a03|pci-1924-0b03))">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
+          <result value="FAILED">
+            <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-1521">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="count"/>
+        <arg name="ingress">TRUE</arg>
+        <arg name="promisc"/>
+        <arg name="isolated">TRUE</arg>
+        <arg name="transfer">TRUE</arg>
+        <arg name="env"/>
+        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.dst_mac.vsid.ifrm_dst_mac.vxlan</arg>
+        <arg name="is_ip6_inner_frame"/>
+        <notes/>
+        <results tags="vdev-failsafe">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-10ee-0100" key="WONTFIX HW-NO-OR-MAC-MATCH" notes="SN1022 has no MAC addresses match in outer rules">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Inconsistent pattern (outer)</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-1521">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924-0903|pci-1924-1903|pci-1924-0923|pci-1924-1923|((rx-low-latency|rx-packed-stream|rx-dpdk)&amp;(pci-1924-0a03|pci-1924-0b03))">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
+          <result value="SKIPPED">
+            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
+          <result value="FAILED">
+            <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+          <result value="SKIPPED">
+            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-159b" key="FLOW-ISOLATE" notes="net/ice does not support rte_flow_isolate()">
+          <result value="SKIPPED">
+            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="count"/>
+        <arg name="ingress">TRUE</arg>
+        <arg name="promisc"/>
+        <arg name="isolated">FALSE</arg>
+        <arg name="transfer">TRUE</arg>
+        <arg name="env"/>
+        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.dst_mac.vsid.ifrm_dst_mac.vxlan</arg>
+        <arg name="is_ip6_inner_frame"/>
+        <notes/>
+        <results tags="vdev-failsafe">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-10ee-0100" key="WONTFIX HW-NO-OR-MAC-MATCH" notes="SN1022 has no MAC addresses match in outer rules">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Inconsistent pattern (outer)</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-1521">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924-0903|pci-1924-1903|pci-1924-0923|pci-1924-1923|((rx-low-latency|rx-packed-stream|rx-dpdk)&amp;(pci-1924-0a03|pci-1924-0b03))">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
+          <result value="FAILED">
+            <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="count"/>
+        <arg name="ingress">TRUE</arg>
+        <arg name="promisc"/>
+        <arg name="isolated">TRUE</arg>
+        <arg name="transfer">TRUE</arg>
+        <arg name="env"/>
+        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.dst_mac.vsid.ifrm_dst_mac.vxlan6</arg>
+        <arg name="is_ip6_inner_frame"/>
+        <notes/>
+        <results tags="vdev-failsafe">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-10ee-0100" key="WONTFIX HW-NO-OR-MAC-MATCH" notes="SN1022 has no MAC addresses match in outer rules">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Inconsistent pattern (outer)</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-1521">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924-0903|pci-1924-1903|pci-1924-0923|pci-1924-1923|((rx-low-latency|rx-packed-stream|rx-dpdk)&amp;(pci-1924-0a03|pci-1924-0b03))">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
+          <result value="SKIPPED">
+            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
+          <result value="FAILED">
+            <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+          <result value="SKIPPED">
+            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-159b" key="FLOW-ISOLATE" notes="net/ice does not support rte_flow_isolate()">
+          <result value="SKIPPED">
+            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="count"/>
+        <arg name="ingress">TRUE</arg>
+        <arg name="promisc"/>
+        <arg name="isolated">FALSE</arg>
+        <arg name="transfer">TRUE</arg>
+        <arg name="env"/>
+        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.dst_mac.vsid.ifrm_dst_mac.vxlan6</arg>
+        <arg name="is_ip6_inner_frame"/>
+        <notes/>
+        <results tags="vdev-failsafe">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-10ee-0100" key="WONTFIX HW-NO-OR-MAC-MATCH" notes="SN1022 has no MAC addresses match in outer rules">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Inconsistent pattern (outer)</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-1521">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924-0903|pci-1924-1903|pci-1924-0923|pci-1924-1923|((rx-low-latency|rx-packed-stream|rx-dpdk)&amp;(pci-1924-0a03|pci-1924-0b03))">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
+          <result value="FAILED">
+            <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-159b" key="NO-FLOW_TRANSFER" notes="ice does not support transfer flow rules">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Only support ingress.</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="count"/>
+        <arg name="ingress">TRUE</arg>
+        <arg name="promisc"/>
+        <arg name="isolated">TRUE</arg>
+        <arg name="transfer">TRUE</arg>
+        <arg name="env"/>
+        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.dst_mac.vsid.ifrm_dst_mac.geneve</arg>
+        <arg name="is_ip6_inner_frame"/>
+        <notes/>
+        <results tags="vdev-failsafe">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-1521">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-10ee-0100" key="WONTFIX HW-GENEVE" notes="SN1022 does not support GENEVE">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924-0903|pci-1924-1903|pci-1924-0923|pci-1924-1923|((rx-low-latency|rx-packed-stream|rx-dpdk)&amp;(pci-1924-0a03|pci-1924-0b03))">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
+          <result value="SKIPPED">
+            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
+          <result value="FAILED">
+            <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+          <result value="SKIPPED">
+            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-159b" key="FLOW-ISOLATE" notes="net/ice does not support rte_flow_isolate()">
+          <result value="SKIPPED">
+            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="count"/>
+        <arg name="ingress">TRUE</arg>
+        <arg name="promisc"/>
+        <arg name="isolated">FALSE</arg>
+        <arg name="transfer">TRUE</arg>
+        <arg name="env"/>
+        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.dst_mac.vsid.ifrm_dst_mac.geneve</arg>
+        <arg name="is_ip6_inner_frame"/>
+        <notes/>
+        <results tags="vdev-failsafe">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-1521">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-10ee-0100" key="WONTFIX HW-GENEVE" notes="SN1022 does not support GENEVE">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924-0903|pci-1924-1903|pci-1924-0923|pci-1924-1923|((rx-low-latency|rx-packed-stream|rx-dpdk)&amp;(pci-1924-0a03|pci-1924-0b03))">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
+          <result value="FAILED">
+            <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-159b" key="NO-GENEVE" notes="ice does not support GENEVE tunnels">
+          <result value="SKIPPED">
+            <verdict>The tunnel type is unsupported</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="count"/>
+        <arg name="ingress">TRUE</arg>
+        <arg name="promisc"/>
+        <arg name="isolated">TRUE</arg>
+        <arg name="transfer">TRUE</arg>
+        <arg name="env"/>
+        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.dst_mac.vsid.ifrm_dst_mac.geneve6</arg>
+        <arg name="is_ip6_inner_frame"/>
+        <notes/>
+        <results tags="vdev-failsafe">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-1521">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-10ee-0100" key="WONTFIX HW-GENEVE" notes="SN1022 does not support GENEVE">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924-0903|pci-1924-1903|pci-1924-0923|pci-1924-1923|((rx-low-latency|rx-packed-stream|rx-dpdk)&amp;(pci-1924-0a03|pci-1924-0b03))">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
+          <result value="SKIPPED">
+            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
+          <result value="FAILED">
+            <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+          <result value="SKIPPED">
+            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-159b" key="FLOW-ISOLATE" notes="net/ice does not support rte_flow_isolate()">
+          <result value="SKIPPED">
+            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="count"/>
+        <arg name="ingress">TRUE</arg>
+        <arg name="promisc"/>
+        <arg name="isolated">FALSE</arg>
+        <arg name="transfer">TRUE</arg>
+        <arg name="env"/>
+        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.dst_mac.vsid.ifrm_dst_mac.geneve6</arg>
+        <arg name="is_ip6_inner_frame"/>
+        <notes/>
+        <results tags="vdev-failsafe">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-1521">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-10ee-0100" key="WONTFIX HW-GENEVE" notes="SN1022 does not support GENEVE">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924-0903|pci-1924-1903|pci-1924-0923|pci-1924-1923|((rx-low-latency|rx-packed-stream|rx-dpdk)&amp;(pci-1924-0a03|pci-1924-0b03))">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041">
+          <result value="SKIPPED">
+            <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
+          <result value="FAILED">
+            <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-159b" key="NO-GENEVE" notes="ice does not support GENEVE tunnels">
+          <result value="SKIPPED">
+            <verdict>The tunnel type is unsupported</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="count"/>
+        <arg name="ingress">TRUE</arg>
+        <arg name="promisc"/>
+        <arg name="isolated">TRUE</arg>
+        <arg name="transfer">TRUE</arg>
+        <arg name="env"/>
+        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.dst_mac.vsid.ifrm_dst_mac.nvgre</arg>
+        <arg name="is_ip6_inner_frame"/>
+        <notes/>
+        <results tags="pci-10ee-0100" key="WONTFIX HW-NO-OR-MAC-MATCH" notes="SN1022 has no MAC addresses match in outer rules">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Inconsistent pattern (outer)</verdict>
+          </result>
+        </results>
+        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
+          <result value="SKIPPED">
+            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+          <result value="SKIPPED">
+            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086-159b" key="FLOW-ISOLATE" notes="net/ice does not support rte_flow_isolate()">
+          <result value="SKIPPED">
+            <verdict>rte_flow_isolate() RPC is unavailable</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="count"/>
+        <arg name="ingress">TRUE</arg>
+        <arg name="promisc"/>
+        <arg name="isolated">FALSE</arg>
+        <arg name="transfer">TRUE</arg>
+        <arg name="env"/>
+        <arg name="flow_rule_pattern">VAR.flow_rule_pattern.dst_mac.vsid.ifrm_dst_mac.nvgre</arg>
+        <arg name="is_ip6_inner_frame"/>
+        <notes/>
+        <results tags="pci-10ee-0100" key="WONTFIX HW-NO-OR-MAC-MATCH" notes="SN1022 has no MAC addresses match in outer rules">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Inconsistent pattern (outer)</verdict>
+          </result>
+        </results>
+        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO PMD does not support RTE flow API yet">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
         <results tags="pci-1924">
           <result value="SKIPPED">
             <verdict>'rte_flow_validate' operation failed: Transfer is not supported</verdict>
@@ -12958,7 +12958,7 @@
             <verdict>'rte_flow_validate' operation failed: Action is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -13020,7 +13020,7 @@
             <verdict>'rte_flow_validate' operation failed: Action is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -13082,7 +13082,7 @@
             <verdict>'rte_flow_validate' operation failed: Action is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -14074,7 +14074,7 @@
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>

--- a/trc/perf.xml
+++ b/trc/perf.xml
@@ -1336,7 +1336,7 @@
         <arg name="testpmd_arg_burst"/>
         <arg name="testpmd_arg_txfreet"/>
         <notes/>
-        <results tags="sfc_efx" key="DPDK-350">
+        <results tags="dpdk" key="DPDK-350" notes="testpmd patches to support TSO are not accepted upstream yet and require respin">
           <result value="SKIPPED">
             <verdict>testpmd does not support '--txonly-tso-mss' option</verdict>
           </result>

--- a/trc/representors.xml
+++ b/trc/representors.xml
@@ -38,6 +38,11 @@
             <verdict>Querying representor information is not supported</verdict>
           </result>
         </results>
+        <results tags="pci-8086-1572" key="TODO">
+          <result value="FAILED">
+            <verdict>Failed to enable VFs</verdict>
+          </result>
+        </results>
       </iter>
     </test>
 

--- a/trc/usecases.xml
+++ b/trc/usecases.xml
@@ -27190,7 +27190,7 @@
       </iter>
     </test>
     <test name="rx_intr" type="script">
-      <objective>Check Rx interrupt</objective>
+      <objective>The test requests Rx queue interrupts on device configuration then checks that Rx interrupts are triggered when enabled</objective>
       <notes/>
       <iter result="PASSED">
         <arg name="env"/>
@@ -27231,6 +27231,11 @@
           <result value="FAILED">
             <verdict>Interrupt was disabled, kept armed and recevied</verdict>
             <verdict>Interrupt is not expected, but received</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="ref://dpdk-bz/1345" notes="net/i40e losses packet after Rx interrupt disable">
+          <result value="FAILED">
+            <verdict>There are no received packets</verdict>
           </result>
         </results>
       </iter>
@@ -27295,6 +27300,11 @@
             <verdict>Cannot bind to Rx queue interrupt: EPERM</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="ref://dpdk-bz/1346" notes="net/i40e does not report Rx interrupt disable for the second packet">
+          <result value="FAILED">
+            <verdict>Interrupt is enabled and expected, but not received</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -27334,6 +27344,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="After device configure interrupt disable is only a hint to device">
           <result value="PASSED">
             <verdict>Interrupt was disabled, kept armed and recevied</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="ref://dpdk-bz/1345" notes="net/i40e losses packet after Rx interrupt disable">
+          <result value="FAILED">
+            <verdict>There are no received packets</verdict>
           </result>
         </results>
       </iter>
@@ -27378,6 +27393,11 @@
             <verdict>Interrupt is not expected, but received</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="ref://dpdk-bz/1345" notes="net/i40e losses packet after Rx interrupt disable">
+          <result value="FAILED">
+            <verdict>There are no received packets</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -27417,6 +27437,11 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="After device configure interrupt disable is only a hint to device">
           <result value="PASSED">
             <verdict>Interrupt was disabled, kept armed and recevied</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="ref://dpdk-bz/1345" notes="net/i40e losses packet after Rx interrupt disable">
+          <result value="FAILED">
+            <verdict>There are no received packets</verdict>
           </result>
         </results>
       </iter>
@@ -27544,6 +27569,11 @@
           </result>
         </results>
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="Interrupt is enabled on device configure, further calls to intr_enable is just a hint to device">
+          <result value="FAILED">
+            <verdict>Interrupt is not expected, but received</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="ref://dpdk-bz/1347" notes="net/i40e reports Rx interrupt just after enable">
           <result value="FAILED">
             <verdict>Interrupt is not expected, but received</verdict>
           </result>

--- a/trc/usecases.xml
+++ b/trc/usecases.xml
@@ -15881,6 +15881,11 @@
             <verdict>Layer 2 packet type is unsupported by the driver</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="RX-PTYPE-VLAN" notes="net/i40e does not report Rx packet type VLAN">
+          <result value="PASSED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -15937,6 +15942,11 @@
             <verdict>Layer 4 packet type is unsupported by the driver</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="RX-PTYPE-VLAN" notes="net/i40e does not report Rx packet type VLAN">
+          <result value="PASSED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -15961,6 +15971,11 @@
           <result value="PASSED">
             <verdict>Layer 3 packet type is unsupported by the driver</verdict>
             <verdict>Layer 4 packet type is unsupported by the driver</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="RX-PTYPE-VLAN" notes="net/i40e does not report Rx packet type VLAN">
+          <result value="PASSED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
           </result>
         </results>
       </iter>
@@ -15990,6 +16005,11 @@
             <verdict>Layer 4 packet type is unsupported by the driver</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="RX-PTYPE-VLAN" notes="net/i40e does not report Rx packet type VLAN">
+          <result value="PASSED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -16017,6 +16037,11 @@
             <verdict>Layer 4 packet type is unsupported by the driver</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="RX-PTYPE-VLAN" notes="net/i40e does not report Rx packet type VLAN">
+          <result value="PASSED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -16042,6 +16067,11 @@
           <result value="PASSED">
             <verdict>Layer 3 packet type is unsupported by the driver</verdict>
             <verdict>Layer 4 packet type is unsupported by the driver</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="RX-PTYPE-VLAN" notes="net/i40e does not report Rx packet type VLAN">
+          <result value="PASSED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
           </result>
         </results>
       </iter>
@@ -16917,6 +16947,11 @@
             <verdict>Packet type is wrong</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="RX-PTYPE-VLAN" notes="net/i40e does not report Rx packet type VLAN">
+          <result value="PASSED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -16973,6 +17008,11 @@
             <verdict>Packet type mismatch: got INNER_L3_UNKNOWN, must be INNER_L3_IPV4_EXT_UNKNOWN</verdict>
             <verdict>Packet type mismatch: got INNER_L4_UNKNOWN, must be INNER_L4_FRAG</verdict>
             <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="RX-PTYPE-VLAN" notes="net/i40e does not report Rx packet type VLAN">
+          <result value="PASSED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
           </result>
         </results>
       </iter>
@@ -17033,6 +17073,11 @@
             <verdict>Packet type is wrong</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="RX-PTYPE-VLAN" notes="net/i40e does not report Rx packet type VLAN">
+          <result value="PASSED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -17083,6 +17128,11 @@
             <verdict>Packet type is wrong</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="RX-PTYPE-VLAN" notes="net/i40e does not report Rx packet type VLAN">
+          <result value="PASSED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -17131,6 +17181,11 @@
             <verdict>Inner layer 2 packet type is unsupported by the driver</verdict>
             <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_NVGRE</verdict>
             <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="RX-PTYPE-VLAN" notes="net/i40e does not report Rx packet type VLAN">
+          <result value="PASSED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
           </result>
         </results>
       </iter>
@@ -17241,6 +17296,11 @@
             <verdict>Packet type is wrong</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="RX-PTYPE-VLAN" notes="net/i40e does not report Rx packet type VLAN">
+          <result value="PASSED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -17299,6 +17359,11 @@
             <verdict>Packet type is wrong</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="RX-PTYPE-VLAN" notes="net/i40e does not report Rx packet type VLAN">
+          <result value="PASSED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -17355,6 +17420,11 @@
             <verdict>Packet type mismatch: got INNER_L3_UNKNOWN, must be INNER_L3_IPV4_EXT_UNKNOWN</verdict>
             <verdict>Packet type mismatch: got INNER_L4_UNKNOWN, must be INNER_L4_UDP</verdict>
             <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="RX-PTYPE-VLAN" notes="net/i40e does not report Rx packet type VLAN">
+          <result value="PASSED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
           </result>
         </results>
       </iter>
@@ -21465,6 +21535,11 @@
             <verdict>Layer 4 packet type is unsupported by the driver</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="RX-PTYPE-VLAN" notes="net/i40e does not report Rx packet type VLAN">
+          <result value="PASSED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -21489,6 +21564,11 @@
           <result value="PASSED">
             <verdict>Layer 3 packet type is unsupported by the driver</verdict>
             <verdict>Layer 4 packet type is unsupported by the driver</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="RX-PTYPE-VLAN" notes="net/i40e does not report Rx packet type VLAN">
+          <result value="PASSED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
           </result>
         </results>
       </iter>
@@ -22198,6 +22278,11 @@
             <verdict>Packet type is wrong</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="RX-PTYPE-VLAN" notes="net/i40e does not report Rx packet type VLAN">
+          <result value="PASSED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -22254,6 +22339,11 @@
             <verdict>Packet type mismatch: got INNER_L3_UNKNOWN, must be INNER_L3_IPV4_EXT_UNKNOWN</verdict>
             <verdict>Packet type mismatch: got INNER_L4_UNKNOWN, must be INNER_L4_FRAG</verdict>
             <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="RX-PTYPE-VLAN" notes="net/i40e does not report Rx packet type VLAN">
+          <result value="PASSED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
           </result>
         </results>
       </iter>
@@ -22314,6 +22404,11 @@
             <verdict>Packet type is wrong</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="RX-PTYPE-VLAN" notes="net/i40e does not report Rx packet type VLAN">
+          <result value="PASSED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -22364,6 +22459,11 @@
             <verdict>Packet type is wrong</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="RX-PTYPE-VLAN" notes="net/i40e does not report Rx packet type VLAN">
+          <result value="PASSED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -22412,6 +22512,11 @@
             <verdict>Inner layer 2 packet type is unsupported by the driver</verdict>
             <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_NVGRE</verdict>
             <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="RX-PTYPE-VLAN" notes="net/i40e does not report Rx packet type VLAN">
+          <result value="PASSED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
           </result>
         </results>
       </iter>
@@ -22522,6 +22627,11 @@
             <verdict>Packet type is wrong</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="RX-PTYPE-VLAN" notes="net/i40e does not report Rx packet type VLAN">
+          <result value="PASSED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -22580,6 +22690,11 @@
             <verdict>Packet type is wrong</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="RX-PTYPE-VLAN" notes="net/i40e does not report Rx packet type VLAN">
+          <result value="PASSED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -22636,6 +22751,11 @@
             <verdict>Packet type mismatch: got INNER_L3_UNKNOWN, must be INNER_L3_IPV4_EXT_UNKNOWN</verdict>
             <verdict>Packet type mismatch: got INNER_L4_UNKNOWN, must be INNER_L4_UDP</verdict>
             <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="RX-PTYPE-VLAN" notes="net/i40e does not report Rx packet type VLAN">
+          <result value="PASSED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
           </result>
         </results>
       </iter>

--- a/trc/usecases.xml
+++ b/trc/usecases.xml
@@ -9325,6 +9325,12 @@
             <verdict>Unexpected checksum offload flags for the packet with bad checksums: expected RTE_MBUF_F_RX_L4_CKSUM_BAD VS obtained RTE_MBUF_F_RX_L4_CKSUM_UNKNOWN</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="IP6-RX_IP_CKSUM_GOOD" notes="net/i40e always report RX_IP_CKSUM_GOOD for IPv6 packets dispite of the fact that there is no checksum in IPv6 case">
+          <result value="FAILED">
+            <verdict>Unexpected checksum offload flags for the packet with good checksums: expected RTE_MBUF_F_RX_IP_CKSUM_UNKNOWN VS obtained RTE_MBUF_F_RX_IP_CKSUM_GOOD</verdict>
+            <verdict>Unexpected checksum offload flags for the packet with bad checksums: expected RTE_MBUF_F_RX_IP_CKSUM_UNKNOWN VS obtained RTE_MBUF_F_RX_IP_CKSUM_GOOD</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -9368,6 +9374,12 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="Driver doesn't set L4_CKSUM_BAD">
           <result value="FAILED">
             <verdict>Unexpected checksum offload flags for the packet with bad checksums: expected RTE_MBUF_F_RX_L4_CKSUM_BAD VS obtained RTE_MBUF_F_RX_L4_CKSUM_UNKNOWN</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="IP6-RX_IP_CKSUM_GOOD" notes="net/i40e always report RX_IP_CKSUM_GOOD for IPv6 packets dispite of the fact that there is no checksum in IPv6 case">
+          <result value="FAILED">
+            <verdict>Unexpected checksum offload flags for the packet with good checksums: expected RTE_MBUF_F_RX_IP_CKSUM_UNKNOWN VS obtained RTE_MBUF_F_RX_IP_CKSUM_GOOD</verdict>
+            <verdict>Unexpected checksum offload flags for the packet with bad checksums: expected RTE_MBUF_F_RX_IP_CKSUM_UNKNOWN VS obtained RTE_MBUF_F_RX_IP_CKSUM_GOOD</verdict>
           </result>
         </results>
       </iter>

--- a/trc/usecases.xml
+++ b/trc/usecases.xml
@@ -16064,6 +16064,11 @@
             <verdict>Layer 2 packet type is unsupported by the driver</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="PASSED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -16094,6 +16099,12 @@
             <verdict>Layer 2 packet type is unsupported by the driver</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Packet type mismatch: got L2_ETHER, must be L2_ETHER_ARP</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -16120,6 +16131,14 @@
             <verdict>Layer 4 packet type is unsupported by the driver</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L3_UNKNOWN, must be L3_IPV4_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_TCP</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -16144,6 +16163,14 @@
           <result value="PASSED">
             <verdict>Layer 3 packet type is unsupported by the driver</verdict>
             <verdict>Layer 4 packet type is unsupported by the driver</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L3_UNKNOWN, must be L3_IPV4_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type is wrong</verdict>
           </result>
         </results>
       </iter>
@@ -16173,6 +16200,14 @@
             <verdict>Layer 4 packet type is unsupported by the driver</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L3_UNKNOWN, must be L3_IPV4_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_FRAG</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -16200,6 +16235,14 @@
             <verdict>Layer 4 packet type is unsupported by the driver</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L3_UNKNOWN, must be L3_IPV4_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_FRAG</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -16225,6 +16268,14 @@
           <result value="PASSED">
             <verdict>Layer 3 packet type is unsupported by the driver</verdict>
             <verdict>Layer 4 packet type is unsupported by the driver</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L3_UNKNOWN, must be L3_IPV4_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_FRAG</verdict>
+            <verdict>Packet type is wrong</verdict>
           </result>
         </results>
       </iter>
@@ -16280,6 +16331,17 @@
           <result value="FAILED">
             <verdict>Inner layer 2 packet type is unsupported by the driver</verdict>
             <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_NVGRE</verdict>
+            <verdict>Packet type mismatch: got INNER_L3_UNKNOWN, must be INNER_L3_IPV4_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got INNER_L4_UNKNOWN, must be INNER_L4_FRAG</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L3_UNKNOWN, must be L3_IPV4_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_GRENAT</verdict>
+            <verdict>Packet type mismatch: got INNER_L2_UNKNOWN, must be INNER_L2_ETHER</verdict>
             <verdict>Packet type mismatch: got INNER_L3_UNKNOWN, must be INNER_L3_IPV4_EXT_UNKNOWN</verdict>
             <verdict>Packet type mismatch: got INNER_L4_UNKNOWN, must be INNER_L4_FRAG</verdict>
             <verdict>Packet type is wrong</verdict>
@@ -16343,6 +16405,17 @@
             <verdict>Packet type is wrong</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L3_UNKNOWN, must be L3_IPV4_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_GRENAT</verdict>
+            <verdict>Packet type mismatch: got INNER_L2_UNKNOWN, must be INNER_L2_ETHER</verdict>
+            <verdict>Packet type mismatch: got INNER_L3_UNKNOWN, must be INNER_L3_IPV4_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got INNER_L4_UNKNOWN, must be INNER_L4_FRAG</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -16401,6 +16474,17 @@
             <verdict>Packet type is wrong</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L3_UNKNOWN, must be L3_IPV4_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_GRENAT</verdict>
+            <verdict>Packet type mismatch: got INNER_L2_UNKNOWN, must be INNER_L2_ETHER</verdict>
+            <verdict>Packet type mismatch: got INNER_L3_UNKNOWN, must be INNER_L3_IPV4_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got INNER_L4_UNKNOWN, must be INNER_L4_FRAG</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -16448,6 +16532,15 @@
           <result value="FAILED">
             <verdict>Inner layer 2 packet type is unsupported by the driver</verdict>
             <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_NVGRE</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L3_UNKNOWN, must be L3_IPV4_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_GRENAT</verdict>
+            <verdict>Packet type mismatch: got INNER_L2_UNKNOWN, must be INNER_L2_ETHER</verdict>
             <verdict>Packet type is wrong</verdict>
           </result>
         </results>
@@ -16501,6 +16594,15 @@
             <verdict>Packet type is wrong</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L3_UNKNOWN, must be L3_IPV4_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_GRENAT</verdict>
+            <verdict>Packet type mismatch: got INNER_L2_UNKNOWN, must be INNER_L2_ETHER_VLAN</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -16551,6 +16653,15 @@
             <verdict>Packet type is wrong</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Inner layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L3_UNKNOWN, must be L3_IPV4_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_GRENAT</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -16598,6 +16709,15 @@
           <result value="FAILED">
             <verdict>Inner layer 2 packet type is unsupported by the driver</verdict>
             <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_NVGRE</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L3_UNKNOWN, must be L3_IPV4_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_GRENAT</verdict>
+            <verdict>Packet type mismatch: got INNER_L2_UNKNOWN, must be INNER_L2_ETHER</verdict>
             <verdict>Packet type is wrong</verdict>
           </result>
         </results>
@@ -16659,6 +16779,17 @@
             <verdict>Packet type is wrong</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L3_UNKNOWN, must be L3_IPV4_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_GRENAT</verdict>
+            <verdict>Packet type mismatch: got INNER_L2_UNKNOWN, must be INNER_L2_ETHER</verdict>
+            <verdict>Packet type mismatch: got INNER_L3_UNKNOWN, must be INNER_L3_IPV4_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got INNER_L4_UNKNOWN, must be INNER_L4_TCP</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -16712,6 +16843,17 @@
           <result value="FAILED">
             <verdict>Inner layer 2 packet type is unsupported by the driver</verdict>
             <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_NVGRE</verdict>
+            <verdict>Packet type mismatch: got INNER_L3_UNKNOWN, must be INNER_L3_IPV4_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got INNER_L4_UNKNOWN, must be INNER_L4_UDP</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L3_UNKNOWN, must be L3_IPV4_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_GRENAT</verdict>
+            <verdict>Packet type mismatch: got INNER_L2_UNKNOWN, must be INNER_L2_ETHER</verdict>
             <verdict>Packet type mismatch: got INNER_L3_UNKNOWN, must be INNER_L3_IPV4_EXT_UNKNOWN</verdict>
             <verdict>Packet type mismatch: got INNER_L4_UNKNOWN, must be INNER_L4_UDP</verdict>
             <verdict>Packet type is wrong</verdict>
@@ -17474,6 +17616,13 @@
           <result value="FAILED">
             <verdict>Inner layer 2 packet type is unsupported by the driver</verdict>
             <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_NVGRE</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Inner layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got INNER_L2_ETHER, must be INNER_L2_UNKNOWN</verdict>
             <verdict>Packet type is wrong</verdict>
           </result>
         </results>
@@ -19472,6 +19621,16 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L3_UNKNOWN, must be L3_IPV4_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_GRENAT</verdict>
+            <verdict>Packet type mismatch: got INNER_L2_UNKNOWN, must be INNER_L2_ETHER</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -19524,6 +19683,16 @@
         <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L3_UNKNOWN, must be L3_IPV4_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_GRENAT</verdict>
+            <verdict>Packet type mismatch: got INNER_L2_UNKNOWN, must be INNER_L2_ETHER_VLAN</verdict>
+            <verdict>Packet type is wrong</verdict>
           </result>
         </results>
       </iter>
@@ -19580,6 +19749,16 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Inner layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L3_UNKNOWN, must be L3_IPV4_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_GRENAT</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -19632,6 +19811,16 @@
         <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L3_UNKNOWN, must be L3_IPV4_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_GRENAT</verdict>
+            <verdict>Packet type mismatch: got INNER_L2_UNKNOWN, must be INNER_L2_ETHER</verdict>
+            <verdict>Packet type is wrong</verdict>
           </result>
         </results>
       </iter>
@@ -19690,6 +19879,18 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L3_UNKNOWN, must be L3_IPV4_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_GRENAT</verdict>
+            <verdict>Packet type mismatch: got INNER_L2_UNKNOWN, must be INNER_L2_ETHER</verdict>
+            <verdict>Packet type mismatch: got INNER_L3_UNKNOWN, must be INNER_L3_IPV4_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got INNER_L4_UNKNOWN, must be INNER_L4_UDP</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -19744,6 +19945,18 @@
         <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L3_UNKNOWN, must be L3_IPV4_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_GRENAT</verdict>
+            <verdict>Packet type mismatch: got INNER_L2_UNKNOWN, must be INNER_L2_ETHER</verdict>
+            <verdict>Packet type mismatch: got INNER_L3_UNKNOWN, must be INNER_L3_IPV4_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got INNER_L4_UNKNOWN, must be INNER_L4_TCP</verdict>
+            <verdict>Packet type is wrong</verdict>
           </result>
         </results>
       </iter>
@@ -19802,6 +20015,18 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L3_UNKNOWN, must be L3_IPV4_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_GRENAT</verdict>
+            <verdict>Packet type mismatch: got INNER_L2_UNKNOWN, must be INNER_L2_ETHER</verdict>
+            <verdict>Packet type mismatch: got INNER_L3_UNKNOWN, must be INNER_L3_IPV4_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got INNER_L4_UNKNOWN, must be INNER_L4_FRAG</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -19858,6 +20083,18 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L3_UNKNOWN, must be L3_IPV4_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_GRENAT</verdict>
+            <verdict>Packet type mismatch: got INNER_L2_UNKNOWN, must be INNER_L2_ETHER</verdict>
+            <verdict>Packet type mismatch: got INNER_L3_UNKNOWN, must be INNER_L3_IPV4_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got INNER_L4_UNKNOWN, must be INNER_L4_FRAG</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -19912,6 +20149,18 @@
         <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L3_UNKNOWN, must be L3_IPV4_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_GRENAT</verdict>
+            <verdict>Packet type mismatch: got INNER_L2_UNKNOWN, must be INNER_L2_ETHER</verdict>
+            <verdict>Packet type mismatch: got INNER_L3_UNKNOWN, must be INNER_L3_IPV4_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got INNER_L4_UNKNOWN, must be INNER_L4_FRAG</verdict>
+            <verdict>Packet type is wrong</verdict>
           </result>
         </results>
       </iter>
@@ -20074,6 +20323,15 @@
         <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Inner layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type mismatch: got INNER_L2_ETHER, must be INNER_L2_UNKNOWN</verdict>
+            <verdict>Packet type is wrong</verdict>
           </result>
         </results>
       </iter>
@@ -20567,6 +20825,14 @@
         <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Inner layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type mismatch: got INNER_L2_ETHER, must be INNER_L2_UNKNOWN</verdict>
+            <verdict>Packet type is wrong</verdict>
           </result>
         </results>
       </iter>
@@ -21139,6 +21405,14 @@
             <verdict>Layer 4 packet type is unsupported by the driver</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L3_UNKNOWN, must be L3_IPV6_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_TCP</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -21163,6 +21437,14 @@
           <result value="PASSED">
             <verdict>Layer 3 packet type is unsupported by the driver</verdict>
             <verdict>Layer 4 packet type is unsupported by the driver</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L3_UNKNOWN, must be L3_IPV6_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type is wrong</verdict>
           </result>
         </results>
       </iter>
@@ -21218,6 +21500,17 @@
           <result value="FAILED">
             <verdict>Inner layer 2 packet type is unsupported by the driver</verdict>
             <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_NVGRE</verdict>
+            <verdict>Packet type mismatch: got INNER_L3_UNKNOWN, must be INNER_L3_IPV4_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got INNER_L4_UNKNOWN, must be INNER_L4_FRAG</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L3_UNKNOWN, must be L3_IPV6_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_GRENAT</verdict>
+            <verdict>Packet type mismatch: got INNER_L2_UNKNOWN, must be INNER_L2_ETHER</verdict>
             <verdict>Packet type mismatch: got INNER_L3_UNKNOWN, must be INNER_L3_IPV4_EXT_UNKNOWN</verdict>
             <verdict>Packet type mismatch: got INNER_L4_UNKNOWN, must be INNER_L4_FRAG</verdict>
             <verdict>Packet type is wrong</verdict>
@@ -21281,6 +21574,17 @@
             <verdict>Packet type is wrong</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L3_UNKNOWN, must be L3_IPV6_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_GRENAT</verdict>
+            <verdict>Packet type mismatch: got INNER_L2_UNKNOWN, must be INNER_L2_ETHER</verdict>
+            <verdict>Packet type mismatch: got INNER_L3_UNKNOWN, must be INNER_L3_IPV4_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got INNER_L4_UNKNOWN, must be INNER_L4_FRAG</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -21339,6 +21643,17 @@
             <verdict>Packet type is wrong</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L3_UNKNOWN, must be L3_IPV6_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_GRENAT</verdict>
+            <verdict>Packet type mismatch: got INNER_L2_UNKNOWN, must be INNER_L2_ETHER</verdict>
+            <verdict>Packet type mismatch: got INNER_L3_UNKNOWN, must be INNER_L3_IPV4_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got INNER_L4_UNKNOWN, must be INNER_L4_FRAG</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -21386,6 +21701,15 @@
           <result value="FAILED">
             <verdict>Inner layer 2 packet type is unsupported by the driver</verdict>
             <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_NVGRE</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L3_UNKNOWN, must be L3_IPV6_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_GRENAT</verdict>
+            <verdict>Packet type mismatch: got INNER_L2_UNKNOWN, must be INNER_L2_ETHER</verdict>
             <verdict>Packet type is wrong</verdict>
           </result>
         </results>
@@ -21439,6 +21763,15 @@
             <verdict>Packet type is wrong</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L3_UNKNOWN, must be L3_IPV6_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_GRENAT</verdict>
+            <verdict>Packet type mismatch: got INNER_L2_UNKNOWN, must be INNER_L2_ETHER_VLAN</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -21489,6 +21822,15 @@
             <verdict>Packet type is wrong</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Inner layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L3_UNKNOWN, must be L3_IPV6_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_GRENAT</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -21536,6 +21878,15 @@
           <result value="FAILED">
             <verdict>Inner layer 2 packet type is unsupported by the driver</verdict>
             <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_NVGRE</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L3_UNKNOWN, must be L3_IPV6_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_GRENAT</verdict>
+            <verdict>Packet type mismatch: got INNER_L2_UNKNOWN, must be INNER_L2_ETHER</verdict>
             <verdict>Packet type is wrong</verdict>
           </result>
         </results>
@@ -21597,6 +21948,17 @@
             <verdict>Packet type is wrong</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L3_UNKNOWN, must be L3_IPV6_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_GRENAT</verdict>
+            <verdict>Packet type mismatch: got INNER_L2_UNKNOWN, must be INNER_L2_ETHER</verdict>
+            <verdict>Packet type mismatch: got INNER_L3_UNKNOWN, must be INNER_L3_IPV4_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got INNER_L4_UNKNOWN, must be INNER_L4_TCP</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -21650,6 +22012,17 @@
           <result value="FAILED">
             <verdict>Inner layer 2 packet type is unsupported by the driver</verdict>
             <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_NVGRE</verdict>
+            <verdict>Packet type mismatch: got INNER_L3_UNKNOWN, must be INNER_L3_IPV4_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got INNER_L4_UNKNOWN, must be INNER_L4_UDP</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L3_UNKNOWN, must be L3_IPV6_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_GRENAT</verdict>
+            <verdict>Packet type mismatch: got INNER_L2_UNKNOWN, must be INNER_L2_ETHER</verdict>
             <verdict>Packet type mismatch: got INNER_L3_UNKNOWN, must be INNER_L3_IPV4_EXT_UNKNOWN</verdict>
             <verdict>Packet type mismatch: got INNER_L4_UNKNOWN, must be INNER_L4_UDP</verdict>
             <verdict>Packet type is wrong</verdict>
@@ -21976,6 +22349,14 @@
           <result value="FAILED">
             <verdict>Inner layer 2 packet type is unsupported by the driver</verdict>
             <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_NVGRE</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Inner layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got INNER_L2_ETHER, must be INNER_L2_UNKNOWN</verdict>
             <verdict>Packet type is wrong</verdict>
           </result>
         </results>
@@ -22412,6 +22793,13 @@
           <result value="FAILED">
             <verdict>Inner layer 2 packet type is unsupported by the driver</verdict>
             <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_NVGRE</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Inner layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got INNER_L2_ETHER, must be INNER_L2_UNKNOWN</verdict>
             <verdict>Packet type is wrong</verdict>
           </result>
         </results>
@@ -24410,6 +24798,16 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L3_UNKNOWN, must be L3_IPV6_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_GRENAT</verdict>
+            <verdict>Packet type mismatch: got INNER_L2_UNKNOWN, must be INNER_L2_ETHER</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -24462,6 +24860,16 @@
         <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L3_UNKNOWN, must be L3_IPV6_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_GRENAT</verdict>
+            <verdict>Packet type mismatch: got INNER_L2_UNKNOWN, must be INNER_L2_ETHER_VLAN</verdict>
+            <verdict>Packet type is wrong</verdict>
           </result>
         </results>
       </iter>
@@ -24518,6 +24926,16 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Inner layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L3_UNKNOWN, must be L3_IPV6_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_GRENAT</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -24570,6 +24988,16 @@
         <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L3_UNKNOWN, must be L3_IPV6_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_GRENAT</verdict>
+            <verdict>Packet type mismatch: got INNER_L2_UNKNOWN, must be INNER_L2_ETHER</verdict>
+            <verdict>Packet type is wrong</verdict>
           </result>
         </results>
       </iter>
@@ -24628,6 +25056,18 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L3_UNKNOWN, must be L3_IPV6_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_GRENAT</verdict>
+            <verdict>Packet type mismatch: got INNER_L2_UNKNOWN, must be INNER_L2_ETHER</verdict>
+            <verdict>Packet type mismatch: got INNER_L3_UNKNOWN, must be INNER_L3_IPV4_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got INNER_L4_UNKNOWN, must be INNER_L4_UDP</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -24682,6 +25122,18 @@
         <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L3_UNKNOWN, must be L3_IPV6_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_GRENAT</verdict>
+            <verdict>Packet type mismatch: got INNER_L2_UNKNOWN, must be INNER_L2_ETHER</verdict>
+            <verdict>Packet type mismatch: got INNER_L3_UNKNOWN, must be INNER_L3_IPV4_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got INNER_L4_UNKNOWN, must be INNER_L4_TCP</verdict>
+            <verdict>Packet type is wrong</verdict>
           </result>
         </results>
       </iter>
@@ -24740,6 +25192,18 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L3_UNKNOWN, must be L3_IPV6_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_GRENAT</verdict>
+            <verdict>Packet type mismatch: got INNER_L2_UNKNOWN, must be INNER_L2_ETHER</verdict>
+            <verdict>Packet type mismatch: got INNER_L3_UNKNOWN, must be INNER_L3_IPV4_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got INNER_L4_UNKNOWN, must be INNER_L4_FRAG</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -24796,6 +25260,18 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L3_UNKNOWN, must be L3_IPV6_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_GRENAT</verdict>
+            <verdict>Packet type mismatch: got INNER_L2_UNKNOWN, must be INNER_L2_ETHER</verdict>
+            <verdict>Packet type mismatch: got INNER_L3_UNKNOWN, must be INNER_L3_IPV4_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got INNER_L4_UNKNOWN, must be INNER_L4_FRAG</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -24850,6 +25326,18 @@
         <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L3_UNKNOWN, must be L3_IPV6_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type mismatch: got TUNNEL_UNKNOWN, must be TUNNEL_GRENAT</verdict>
+            <verdict>Packet type mismatch: got INNER_L2_UNKNOWN, must be INNER_L2_ETHER</verdict>
+            <verdict>Packet type mismatch: got INNER_L3_UNKNOWN, must be INNER_L3_IPV4_EXT_UNKNOWN</verdict>
+            <verdict>Packet type mismatch: got INNER_L4_UNKNOWN, must be INNER_L4_FRAG</verdict>
+            <verdict>Packet type is wrong</verdict>
           </result>
         </results>
       </iter>
@@ -25012,6 +25500,15 @@
         <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>Inner layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type mismatch: got INNER_L2_ETHER, must be INNER_L2_UNKNOWN</verdict>
+            <verdict>Packet type is wrong</verdict>
           </result>
         </results>
       </iter>
@@ -26878,6 +27375,12 @@
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
+            <verdict>RTE_MBUF_F_RX_QINQ flag is not set for double-tagged packet when QinQ stripping is supported</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -26899,6 +27402,12 @@
         <results tags="rx-datapath-ef100" key="NO-RX-VLAN-WO-STRIPPING" notes="sfc does not provide VLAN TCI without stripping">
           <result value="PASSED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
+            <verdict>RTE_MBUF_F_RX_QINQ flag is not set for double-tagged packet when QinQ stripping is supported</verdict>
           </result>
         </results>
       </iter>
@@ -26924,6 +27433,12 @@
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
+            <verdict>RTE_MBUF_F_RX_QINQ flag is not set for double-tagged packet when QinQ stripping is supported</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -26945,6 +27460,12 @@
         <results tags="rx-datapath-ef100" key="NO-RX-VLAN-WO-STRIPPING" notes="sfc does not provide VLAN TCI without stripping">
           <result value="PASSED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
+            <verdict>RTE_MBUF_F_RX_QINQ flag is not set for double-tagged packet when QinQ stripping is supported</verdict>
           </result>
         </results>
       </iter>
@@ -26970,6 +27491,12 @@
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
+            <verdict>RTE_MBUF_F_RX_QINQ flag is not set for double-tagged packet when QinQ stripping is supported</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -26993,6 +27520,12 @@
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
+            <verdict>RTE_MBUF_F_RX_QINQ flag is not set for double-tagged packet when QinQ stripping is supported</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -27014,6 +27547,12 @@
         <results tags="rx-datapath-ef100" key="NO-RX-VLAN-WO-STRIPPING" notes="sfc does not provide VLAN TCI without stripping">
           <result value="PASSED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
+            <verdict>RTE_MBUF_F_RX_QINQ flag is not set for double-tagged packet when QinQ stripping is supported</verdict>
           </result>
         </results>
       </iter>
@@ -27059,6 +27598,12 @@
         <results tags="rx-datapath-ef100" key="NO-RX-VLAN-WO-STRIPPING" notes="sfc does not provide VLAN TCI without stripping">
           <result value="PASSED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
+            <verdict>RTE_MBUF_F_RX_QINQ flag is not set for double-tagged packet when QinQ stripping is supported</verdict>
           </result>
         </results>
       </iter>
@@ -27239,6 +27784,12 @@
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
+            <verdict>RTE_MBUF_F_RX_QINQ flag is not set for double-tagged packet when QinQ stripping is supported</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -27392,6 +27943,12 @@
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
+            <verdict>RTE_MBUF_F_RX_QINQ flag is not set for double-tagged packet when QinQ stripping is supported</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -27407,6 +27964,12 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041">
           <result value="PASSED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
+            <verdict>RTE_MBUF_F_RX_QINQ flag is not set for double-tagged packet when QinQ stripping is supported</verdict>
           </result>
         </results>
       </iter>
@@ -27426,6 +27989,12 @@
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
+            <verdict>RTE_MBUF_F_RX_QINQ flag is not set for double-tagged packet when QinQ stripping is supported</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -27441,6 +28010,12 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041">
           <result value="PASSED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
+            <verdict>RTE_MBUF_F_RX_QINQ flag is not set for double-tagged packet when QinQ stripping is supported</verdict>
           </result>
         </results>
       </iter>
@@ -27460,6 +28035,12 @@
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
+            <verdict>RTE_MBUF_F_RX_QINQ flag is not set for double-tagged packet when QinQ stripping is supported</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -27477,6 +28058,12 @@
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
+            <verdict>RTE_MBUF_F_RX_QINQ flag is not set for double-tagged packet when QinQ stripping is supported</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -27492,6 +28079,12 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041">
           <result value="PASSED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
+            <verdict>RTE_MBUF_F_RX_QINQ flag is not set for double-tagged packet when QinQ stripping is supported</verdict>
           </result>
         </results>
       </iter>
@@ -27521,6 +28114,12 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041">
           <result value="PASSED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
+            <verdict>RTE_MBUF_F_RX_QINQ flag is not set for double-tagged packet when QinQ stripping is supported</verdict>
           </result>
         </results>
       </iter>
@@ -27735,6 +28334,12 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
+            <verdict>RTE_MBUF_F_RX_QINQ flag is not set for double-tagged packet when QinQ stripping is supported</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -28003,6 +28608,12 @@
             <verdict>QinQ strip is requested but not available</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>1 unexpected packets received</verdict>
+            <verdict>Rx operation checks failed</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -28028,6 +28639,12 @@
         <results tags="rx-datapath-ef100" key="NO-QINQ-STRIP" notes="Not supported by FW yet">
           <result value="SKIPPED">
             <verdict>QinQ strip is requested but not available</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>1 unexpected packets received</verdict>
+            <verdict>Rx operation checks failed</verdict>
           </result>
         </results>
       </iter>
@@ -28057,6 +28674,12 @@
             <verdict>QinQ strip is requested but not available</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>1 unexpected packets received</verdict>
+            <verdict>Rx operation checks failed</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -28082,6 +28705,12 @@
         <results tags="rx-datapath-ef100" key="NO-QINQ-STRIP" notes="Not supported by FW yet">
           <result value="SKIPPED">
             <verdict>QinQ strip is requested but not available</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>1 unexpected packets received</verdict>
+            <verdict>Rx operation checks failed</verdict>
           </result>
         </results>
       </iter>
@@ -28111,6 +28740,12 @@
             <verdict>QinQ strip is requested but not available</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>1 unexpected packets received</verdict>
+            <verdict>Rx operation checks failed</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -28138,6 +28773,12 @@
             <verdict>QinQ strip is requested but not available</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>1 unexpected packets received</verdict>
+            <verdict>Rx operation checks failed</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -28163,6 +28804,12 @@
         <results tags="rx-datapath-ef100" key="NO-QINQ-STRIP" notes="Not supported by FW yet">
           <result value="SKIPPED">
             <verdict>QinQ strip is requested but not available</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>1 unexpected packets received</verdict>
+            <verdict>Rx operation checks failed</verdict>
           </result>
         </results>
       </iter>
@@ -28283,6 +28930,12 @@
             <verdict>QinQ strip is requested but not available</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>1 unexpected packets received</verdict>
+            <verdict>Rx operation checks failed</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -28345,6 +28998,12 @@
         <results tags="rx-datapath-ef100" key="NO-QINQ-STRIP" notes="Not supported by FW yet">
           <result value="SKIPPED">
             <verdict>QinQ strip is requested but not available</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>1 unexpected packets received</verdict>
+            <verdict>Rx operation checks failed</verdict>
           </result>
         </results>
       </iter>
@@ -28814,6 +29473,12 @@
             <verdict>QinQ strip is requested but not available</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>1 unexpected packets received</verdict>
+            <verdict>Rx operation checks failed</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -28839,6 +29504,12 @@
         <results tags="rx-datapath-ef100" key="ref://amd-jira/DPDK-161" notes="Not supported by FW yet">
           <result value="SKIPPED">
             <verdict>QinQ strip is requested but not available</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>1 unexpected packets received</verdict>
+            <verdict>Rx operation checks failed</verdict>
           </result>
         </results>
       </iter>
@@ -28868,6 +29539,12 @@
             <verdict>QinQ strip is requested but not available</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>1 unexpected packets received</verdict>
+            <verdict>Rx operation checks failed</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -28893,6 +29570,12 @@
         <results tags="rx-datapath-ef100" key="ref://amd-jira/DPDK-161" notes="Not supported by FW yet">
           <result value="SKIPPED">
             <verdict>QinQ strip is requested but not available</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>1 unexpected packets received</verdict>
+            <verdict>Rx operation checks failed</verdict>
           </result>
         </results>
       </iter>
@@ -28922,6 +29605,12 @@
             <verdict>QinQ strip is requested but not available</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>1 unexpected packets received</verdict>
+            <verdict>Rx operation checks failed</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -28949,6 +29638,12 @@
             <verdict>QinQ strip is requested but not available</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>1 unexpected packets received</verdict>
+            <verdict>Rx operation checks failed</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -28974,6 +29669,12 @@
         <results tags="rx-datapath-ef100" key="ref://amd-jira/DPDK-161" notes="Not supported by FW yet">
           <result value="SKIPPED">
             <verdict>QinQ strip is requested but not available</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>1 unexpected packets received</verdict>
+            <verdict>Rx operation checks failed</verdict>
           </result>
         </results>
       </iter>
@@ -29104,6 +29805,12 @@
             <verdict>QinQ strip is requested but not available</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>1 unexpected packets received</verdict>
+            <verdict>Rx operation checks failed</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -29166,6 +29873,12 @@
         <results tags="rx-datapath-ef100" key="ref://amd-jira/DPDK-161" notes="Not supported by FW yet">
           <result value="SKIPPED">
             <verdict>QinQ strip is requested but not available</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>1 unexpected packets received</verdict>
+            <verdict>Rx operation checks failed</verdict>
           </result>
         </results>
       </iter>
@@ -30277,6 +30990,12 @@
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
+            <verdict>RTE_MBUF_F_RX_QINQ flag is not set for double-tagged packet when QinQ stripping is supported</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -30298,6 +31017,12 @@
         <results tags="rx-datapath-ef100" key="NO-RX-VLAN-WO-STRIPPING" notes="sfc does not provide VLAN TCI without stripping">
           <result value="PASSED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
+            <verdict>RTE_MBUF_F_RX_QINQ flag is not set for double-tagged packet when QinQ stripping is supported</verdict>
           </result>
         </results>
       </iter>
@@ -30343,6 +31068,12 @@
         <results tags="rx-datapath-ef100" key="NO-RX-VLAN-WO-STRIPPING" notes="sfc does not provide VLAN TCI without stripping">
           <result value="PASSED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
+            <verdict>RTE_MBUF_F_RX_QINQ flag is not set for double-tagged packet when QinQ stripping is supported</verdict>
           </result>
         </results>
       </iter>
@@ -30481,6 +31212,12 @@
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
+            <verdict>RTE_MBUF_F_RX_QINQ flag is not set for double-tagged packet when QinQ stripping is supported</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -30569,6 +31306,12 @@
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
+            <verdict>RTE_MBUF_F_RX_QINQ flag is not set for double-tagged packet when QinQ stripping is supported</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -30584,6 +31327,12 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041">
           <result value="PASSED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
+            <verdict>RTE_MBUF_F_RX_QINQ flag is not set for double-tagged packet when QinQ stripping is supported</verdict>
           </result>
         </results>
       </iter>
@@ -30613,6 +31362,12 @@
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041">
           <result value="PASSED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
+            <verdict>RTE_MBUF_F_RX_QINQ flag is not set for double-tagged packet when QinQ stripping is supported</verdict>
           </result>
         </results>
       </iter>
@@ -30755,6 +31510,12 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
+            <verdict>RTE_MBUF_F_RX_QINQ flag is not set for double-tagged packet when QinQ stripping is supported</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -30888,6 +31649,12 @@
             <verdict>QinQ strip is requested but not available</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>1 unexpected packets received</verdict>
+            <verdict>Rx operation checks failed</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -30913,6 +31680,12 @@
         <results tags="rx-datapath-ef100" key="NO-QINQ-STRIP" notes="Not supported by FW yet">
           <result value="SKIPPED">
             <verdict>QinQ strip is requested but not available</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>1 unexpected packets received</verdict>
+            <verdict>Rx operation checks failed</verdict>
           </result>
         </results>
       </iter>
@@ -31033,6 +31806,12 @@
             <verdict>QinQ strip is requested but not available</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>1 unexpected packets received</verdict>
+            <verdict>Rx operation checks failed</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -31095,6 +31874,12 @@
         <results tags="rx-datapath-ef100" key="NO-QINQ-STRIP" notes="Not supported by FW yet">
           <result value="SKIPPED">
             <verdict>QinQ strip is requested but not available</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>1 unexpected packets received</verdict>
+            <verdict>Rx operation checks failed</verdict>
           </result>
         </results>
       </iter>
@@ -31242,6 +32027,12 @@
             <verdict>QinQ strip is requested but not available</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>1 unexpected packets received</verdict>
+            <verdict>Rx operation checks failed</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -31267,6 +32058,12 @@
         <results tags="rx-datapath-ef100" key="ref://amd-jira/DPDK-161" notes="Not supported by FW yet">
           <result value="SKIPPED">
             <verdict>QinQ strip is requested but not available</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>1 unexpected packets received</verdict>
+            <verdict>Rx operation checks failed</verdict>
           </result>
         </results>
       </iter>
@@ -31397,6 +32194,12 @@
             <verdict>QinQ strip is requested but not available</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>1 unexpected packets received</verdict>
+            <verdict>Rx operation checks failed</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -31459,6 +32262,12 @@
         <results tags="rx-datapath-ef100" key="ref://amd-jira/DPDK-161" notes="Not supported by FW yet">
           <result value="SKIPPED">
             <verdict>QinQ strip is requested but not available</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="QINQ" notes="net/i40e does not support QINQ or TPID used by the test is not supported">
+          <result value="FAILED">
+            <verdict>1 unexpected packets received</verdict>
+            <verdict>Rx operation checks failed</verdict>
           </result>
         </results>
       </iter>

--- a/trc/usecases.xml
+++ b/trc/usecases.xml
@@ -32719,6 +32719,11 @@
             <verdict>'rte_flow_validate' operation failed: Invalid input set</verdict>
           </result>
         </results>
+        <results tags="net_virtio" notes="VirtIO PMD does not support RTE flow API">
+          <result value="SKIPPED">
+            <verdict>'rte_flow_validate' operation failed: Function not implemented</verdict>
+          </result>
+        </results>
       </iter>
     </test>
   </iter>

--- a/trc/usecases.xml
+++ b/trc/usecases.xml
@@ -32684,6 +32684,11 @@
         <arg name="tx_tmpl"/>
         <arg name="flow_rule_pattern"/>
         <notes/>
+        <results tags="net_i40e" key="FLOW-PATTERN-DMAC" notes="net/i40e does not support flow pattern with destination MAC in L2 case">
+          <result value="FAILED">
+            <verdict>'rte_flow_validate' operation failed: Invalid input set</verdict>
+          </result>
+        </results>
       </iter>
     </test>
   </iter>

--- a/trc/usecases.xml
+++ b/trc/usecases.xml
@@ -15722,6 +15722,11 @@
             <verdict>Tx descriptor status retrieval is not supported</verdict>
           </result>
         </results>
+        <results tags="net_i40e">
+          <result value="PASSED">
+            <verdict>Status of the first descriptor is FULL after single Tx burst</verdict>
+          </result>
+        </results>
       </iter>
     </test>
     <test name="tunnel_udp_port_config" type="script">

--- a/trc/usecases.xml
+++ b/trc/usecases.xml
@@ -1752,7 +1752,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -1809,7 +1809,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -1866,7 +1866,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -1923,7 +1923,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -1980,7 +1980,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -2037,7 +2037,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -2094,7 +2094,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -2151,7 +2151,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -2208,7 +2208,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -2265,7 +2265,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -2322,7 +2322,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -2379,7 +2379,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -2436,7 +2436,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -2493,7 +2493,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -2550,7 +2550,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -2607,7 +2607,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -2664,7 +2664,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -2721,7 +2721,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -2778,7 +2778,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -2835,7 +2835,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -2892,7 +2892,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -2949,7 +2949,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -3006,7 +3006,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -3063,7 +3063,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -3120,7 +3120,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -3177,7 +3177,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -3234,7 +3234,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -4644,7 +4644,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -4701,7 +4701,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -4758,7 +4758,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -4815,7 +4815,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -4872,7 +4872,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -4929,7 +4929,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -4986,7 +4986,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -5043,7 +5043,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -5100,7 +5100,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -5157,7 +5157,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -5214,7 +5214,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -5271,7 +5271,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -5328,7 +5328,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -5385,7 +5385,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -5442,7 +5442,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -5499,7 +5499,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -5556,7 +5556,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -5613,7 +5613,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -5670,7 +5670,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -5727,7 +5727,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -5784,7 +5784,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -5841,7 +5841,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -5898,7 +5898,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -5955,7 +5955,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -6012,7 +6012,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -6069,7 +6069,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -6126,7 +6126,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -7433,7 +7433,7 @@
             <verdict>Packet larger than MTU is unexpectedly received</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="SET-MTU-STARTED" notes="net/i40e does not allow to set MTU when device is started">
+        <results tags="net_i40e" key="SET-MTU-STARTED" notes="net/i40e does not allow to set MTU when device is started">
           <result value="FAILED">
             <verdict>rpc_rte_eth_dev_set_mtu() failed: RPC-EBUSY</verdict>
           </result>
@@ -7456,7 +7456,7 @@
             <verdict>Packet larger than MTU is unexpectedly received</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="SET-MTU-STARTED" notes="net/i40e does not allow to set MTU when device is started">
+        <results tags="net_i40e" key="SET-MTU-STARTED" notes="net/i40e does not allow to set MTU when device is started">
           <result value="FAILED">
             <verdict>rpc_rte_eth_dev_set_mtu() failed: RPC-EBUSY</verdict>
           </result>
@@ -7479,7 +7479,7 @@
             <verdict>Packet larger than MTU is unexpectedly received</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="SET-MTU-STARTED" notes="net/i40e does not allow to set MTU when device is started">
+        <results tags="net_i40e" key="SET-MTU-STARTED" notes="net/i40e does not allow to set MTU when device is started">
           <result value="FAILED">
             <verdict>rpc_rte_eth_dev_set_mtu() failed: RPC-EBUSY</verdict>
           </result>
@@ -7507,7 +7507,7 @@
             <verdict>Packet larger than MTU is unexpectedly received</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="SET-MTU-STARTED" notes="net/i40e does not allow to set MTU when device is started">
+        <results tags="net_i40e" key="SET-MTU-STARTED" notes="net/i40e does not allow to set MTU when device is started">
           <result value="FAILED">
             <verdict>rpc_rte_eth_dev_set_mtu() failed: RPC-EBUSY</verdict>
           </result>
@@ -7535,7 +7535,7 @@
             <verdict>Packet larger than MTU is unexpectedly received</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="SET-MTU-STARTED" notes="net/i40e does not allow to set MTU when device is started">
+        <results tags="net_i40e" key="SET-MTU-STARTED" notes="net/i40e does not allow to set MTU when device is started">
           <result value="FAILED">
             <verdict>rpc_rte_eth_dev_set_mtu() failed: RPC-EBUSY</verdict>
           </result>
@@ -7563,7 +7563,7 @@
             <verdict>Packet larger than MTU is unexpectedly received</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="SET-MTU-STARTED" notes="net/i40e does not allow to set MTU when device is started">
+        <results tags="net_i40e" key="SET-MTU-STARTED" notes="net/i40e does not allow to set MTU when device is started">
           <result value="FAILED">
             <verdict>rpc_rte_eth_dev_set_mtu() failed: RPC-EBUSY</verdict>
           </result>
@@ -7780,7 +7780,7 @@
             <verdict>RSS redirection table query failed: EINVAL</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="ref://dpdk-bz/1127" notes="i40e does initialize RSS RETA on configure">
+        <results tags="net_i40e" key="ref://dpdk-bz/1127" notes="i40e does initialize RSS RETA on configure">
           <result value="FAILED">
             <verdict>RETA has been filled incorrectly.</verdict>
           </result>
@@ -7806,7 +7806,7 @@
             <verdict>RSS redirection table query failed: EINVAL</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="ref://dpdk-bz/1127" notes="i40e does initialize RSS RETA on configure">
+        <results tags="net_i40e" key="ref://dpdk-bz/1127" notes="i40e does initialize RSS RETA on configure">
           <result value="FAILED">
             <verdict>RETA has been filled incorrectly.</verdict>
           </result>
@@ -7832,7 +7832,7 @@
             <verdict>RSS redirection table query failed: EINVAL</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="ref://dpdk-bz/1127" notes="i40e does initialize RSS RETA on configure">
+        <results tags="net_i40e" key="ref://dpdk-bz/1127" notes="i40e does initialize RSS RETA on configure">
           <result value="FAILED">
             <verdict>RETA has been filled incorrectly.</verdict>
           </result>
@@ -7858,7 +7858,7 @@
             <verdict>RSS redirection table query failed: EINVAL</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="ref://dpdk-bz/1127" notes="i40e does initialize RSS RETA on configure">
+        <results tags="net_i40e" key="ref://dpdk-bz/1127" notes="i40e does initialize RSS RETA on configure">
           <result value="FAILED">
             <verdict>RETA has been filled incorrectly.</verdict>
           </result>
@@ -7926,7 +7926,7 @@
             <verdict>rte_eth_dev_configure() failed: RPC-EOPNOTSUPP</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="ref://dpdk-bz/1127" notes="i40e does initialize RSS RETA on configure">
+        <results tags="net_i40e" key="ref://dpdk-bz/1127" notes="i40e does initialize RSS RETA on configure">
           <result value="FAILED">
             <verdict>RETA has been filled incorrectly.</verdict>
           </result>
@@ -7952,7 +7952,7 @@
             <verdict>rte_eth_dev_configure() failed: RPC-EOPNOTSUPP</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="ref://dpdk-bz/1127" notes="i40e does initialize RSS RETA on configure">
+        <results tags="net_i40e" key="ref://dpdk-bz/1127" notes="i40e does initialize RSS RETA on configure">
           <result value="FAILED">
             <verdict>RETA has been filled incorrectly.</verdict>
           </result>
@@ -7978,7 +7978,7 @@
             <verdict>rte_eth_dev_configure() failed: RPC-EOPNOTSUPP</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="ref://dpdk-bz/1127" notes="i40e does initialize RSS RETA on configure">
+        <results tags="net_i40e" key="ref://dpdk-bz/1127" notes="i40e does initialize RSS RETA on configure">
           <result value="FAILED">
             <verdict>RETA has been filled incorrectly.</verdict>
           </result>
@@ -8004,7 +8004,7 @@
             <verdict>rte_eth_dev_configure() failed: RPC-EOPNOTSUPP</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="ref://dpdk-bz/1127" notes="i40e does initialize RSS RETA on configure">
+        <results tags="net_i40e" key="ref://dpdk-bz/1127" notes="i40e does initialize RSS RETA on configure">
           <result value="FAILED">
             <verdict>RETA has been filled incorrectly.</verdict>
           </result>
@@ -8072,7 +8072,7 @@
             <verdict>rte_eth_dev_configure() failed: RPC-EOPNOTSUPP</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="ref://dpdk-bz/1127" notes="i40e does initialize RSS RETA on configure">
+        <results tags="net_i40e" key="ref://dpdk-bz/1127" notes="i40e does initialize RSS RETA on configure">
           <result value="FAILED">
             <verdict>RETA has been filled incorrectly.</verdict>
           </result>
@@ -8098,7 +8098,7 @@
             <verdict>rte_eth_dev_configure() failed: RPC-EOPNOTSUPP</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="ref://dpdk-bz/1127" notes="i40e does initialize RSS RETA on configure">
+        <results tags="net_i40e" key="ref://dpdk-bz/1127" notes="i40e does initialize RSS RETA on configure">
           <result value="FAILED">
             <verdict>RETA has been filled incorrectly.</verdict>
           </result>
@@ -8124,7 +8124,7 @@
             <verdict>rte_eth_dev_configure() failed: RPC-EOPNOTSUPP</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="ref://dpdk-bz/1127" notes="i40e does initialize RSS RETA on configure">
+        <results tags="net_i40e" key="ref://dpdk-bz/1127" notes="i40e does initialize RSS RETA on configure">
           <result value="FAILED">
             <verdict>RETA has been filled incorrectly.</verdict>
           </result>
@@ -8150,7 +8150,7 @@
             <verdict>rte_eth_dev_configure() failed: RPC-EOPNOTSUPP</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="ref://dpdk-bz/1127" notes="i40e does initialize RSS RETA on configure">
+        <results tags="net_i40e" key="ref://dpdk-bz/1127" notes="i40e does initialize RSS RETA on configure">
           <result value="FAILED">
             <verdict>RETA has been filled incorrectly.</verdict>
           </result>
@@ -8218,7 +8218,7 @@
             <verdict>rte_eth_dev_configure() failed: RPC-EOPNOTSUPP</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="ref://dpdk-bz/1127" notes="i40e does initialize RSS RETA on configure">
+        <results tags="net_i40e" key="ref://dpdk-bz/1127" notes="i40e does initialize RSS RETA on configure">
           <result value="FAILED">
             <verdict>RETA has been filled incorrectly.</verdict>
           </result>
@@ -8244,7 +8244,7 @@
             <verdict>rte_eth_dev_configure() failed: RPC-EOPNOTSUPP</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="ref://dpdk-bz/1127" notes="i40e does initialize RSS RETA on configure">
+        <results tags="net_i40e" key="ref://dpdk-bz/1127" notes="i40e does initialize RSS RETA on configure">
           <result value="FAILED">
             <verdict>RETA has been filled incorrectly.</verdict>
           </result>
@@ -8270,7 +8270,7 @@
             <verdict>rte_eth_dev_configure() failed: RPC-EOPNOTSUPP</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="ref://dpdk-bz/1127" notes="i40e does initialize RSS RETA on configure">
+        <results tags="net_i40e" key="ref://dpdk-bz/1127" notes="i40e does initialize RSS RETA on configure">
           <result value="FAILED">
             <verdict>RETA has been filled incorrectly.</verdict>
           </result>
@@ -8296,7 +8296,7 @@
             <verdict>rte_eth_dev_configure() failed: RPC-EOPNOTSUPP</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="ref://dpdk-bz/1127" notes="i40e does initialize RSS RETA on configure">
+        <results tags="net_i40e" key="ref://dpdk-bz/1127" notes="i40e does initialize RSS RETA on configure">
           <result value="FAILED">
             <verdict>RETA has been filled incorrectly.</verdict>
           </result>
@@ -8398,7 +8398,7 @@
             <verdict>RSS offload flag is set when offload is disabled</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="WONTFIX I40E-RSS" notes="The offload is enabled unconditionally in MQ mode RSS">
+        <results tags="net_i40e" key="WONTFIX I40E-RSS" notes="The offload is enabled unconditionally in MQ mode RSS">
           <result value="PASSED">
             <verdict>RSS offload flag is set when offload is disabled</verdict>
           </result>
@@ -8457,7 +8457,7 @@
             <verdict>RSS offload flag is set when offload is disabled</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="WONTFIX I40E-RSS" notes="The offload is enabled unconditionally in MQ mode RSS">
+        <results tags="net_i40e" key="WONTFIX I40E-RSS" notes="The offload is enabled unconditionally in MQ mode RSS">
           <result value="PASSED">
             <verdict>RSS offload flag is set when offload is disabled</verdict>
           </result>
@@ -8521,7 +8521,7 @@
             <verdict>RSS offload flag is set when offload is disabled</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="WONTFIX I40E-RSS" notes="The offload is enabled unconditionally in MQ mode RSS">
+        <results tags="net_i40e" key="WONTFIX I40E-RSS" notes="The offload is enabled unconditionally in MQ mode RSS">
           <result value="PASSED">
             <verdict>RSS offload flag is set when offload is disabled</verdict>
           </result>
@@ -9073,7 +9073,7 @@
             <verdict>Rx scatter is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="SET-MTU-STARTED" notes="i40e does not allow to set MTU in started state">
+        <results tags="net_i40e" key="SET-MTU-STARTED" notes="i40e does not allow to set MTU in started state">
           <result value="FAILED">
             <verdict>rte_eth_dev_set_mtu() failed (-EBUSY)</verdict>
           </result>
@@ -9189,7 +9189,7 @@
             <verdict>Rx IP checksum offload is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="RX-CKSUM-IPv4-ALWAYS" notes="net/i40e always fills in Rx checksum offload results for TCP/UDP-IPv4">
+        <results tags="net_i40e" key="RX-CKSUM-IPv4-ALWAYS" notes="net/i40e always fills in Rx checksum offload results for TCP/UDP-IPv4">
           <result value="PASSED">
             <verdict>Rx checksum offload happened unexpectedly for the packet with good checksums</verdict>
             <verdict>Rx checksum offload happened unexpectedly for the packet with bad checksums</verdict>
@@ -9249,7 +9249,7 @@
             <verdict>Rx IP checksum offload is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="RX-CKSUM-IPv4-ALWAYS" notes="net/i40e always fills in Rx checksum offload results for TCP/UDP-IPv4">
+        <results tags="net_i40e" key="RX-CKSUM-IPv4-ALWAYS" notes="net/i40e always fills in Rx checksum offload results for TCP/UDP-IPv4">
           <result value="PASSED">
             <verdict>Rx checksum offload happened unexpectedly for the packet with good checksums</verdict>
             <verdict>Rx checksum offload happened unexpectedly for the packet with bad checksums</verdict>
@@ -9454,7 +9454,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="RX-CKSUM-IPv4-ALWAYS" notes="net/i40e always fills in Rx checksum offload results for TCP/UDP-IPv4">
+        <results tags="net_i40e" key="RX-CKSUM-IPv4-ALWAYS" notes="net/i40e always fills in Rx checksum offload results for TCP/UDP-IPv4">
           <result value="PASSED">
             <verdict>Rx checksum offload happened unexpectedly for the packet with good checksums</verdict>
             <verdict>Rx checksum offload happened unexpectedly for the packet with bad checksums</verdict>
@@ -9580,7 +9580,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -9644,7 +9644,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -9683,7 +9683,7 @@
             <verdict>Rx IP checksum offload is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="RX-CKSUM-IPv4-ALWAYS" notes="net/i40e always fills in Rx checksum offload results for TCP/UDP-IPv4">
+        <results tags="net_i40e" key="RX-CKSUM-IPv4-ALWAYS" notes="net/i40e always fills in Rx checksum offload results for TCP/UDP-IPv4">
           <result value="PASSED">
             <verdict>Rx checksum offload happened unexpectedly for the packet with good checksums</verdict>
             <verdict>Rx checksum offload happened unexpectedly for the packet with bad checksums</verdict>
@@ -9746,7 +9746,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="RX-CKSUM-IPv4-ALWAYS" notes="net/i40e always fills in Rx checksum offload results for TCP/UDP-IPv4">
+        <results tags="net_i40e" key="RX-CKSUM-IPv4-ALWAYS" notes="net/i40e always fills in Rx checksum offload results for TCP/UDP-IPv4">
           <result value="PASSED">
             <verdict>Rx checksum offload happened unexpectedly for the packet with good checksums</verdict>
             <verdict>Rx checksum offload happened unexpectedly for the packet with bad checksums</verdict>
@@ -9872,7 +9872,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -9936,7 +9936,7 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -10044,7 +10044,7 @@
             <verdict>rte_eth_dev_configure() failed: RPC-EOPNOTSUPP</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="ref://dpdk-bz/1102" notes="i40e: enabling Rx/Tx queue deferred start has no effect">
+        <results tags="net_i40e" key="ref://dpdk-bz/1102" notes="i40e: enabling Rx/Tx queue deferred start has no effect">
           <result value="FAILED">
             <verdict>Known but unexpected packets recevied</verdict>
           </result>
@@ -10075,7 +10075,7 @@
             <verdict>rte_eth_dev_configure() failed: RPC-EOPNOTSUPP</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="ref://dpdk-bz/1102" notes="i40e: enabling Rx/Tx queue deferred start has no effect">
+        <results tags="net_i40e" key="ref://dpdk-bz/1102" notes="i40e: enabling Rx/Tx queue deferred start has no effect">
           <result value="FAILED">
             <verdict>Known but unexpected packets recevied</verdict>
           </result>
@@ -10106,7 +10106,7 @@
             <verdict>rte_eth_dev_configure() failed: RPC-EOPNOTSUPP</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="ref://dpdk-bz/1102" notes="i40e: enabling Rx/Tx queue deferred start has no effect">
+        <results tags="net_i40e" key="ref://dpdk-bz/1102" notes="i40e: enabling Rx/Tx queue deferred start has no effect">
           <result value="FAILED">
             <verdict>Known but unexpected packets recevied</verdict>
           </result>
@@ -10137,7 +10137,7 @@
             <verdict>rte_eth_dev_configure() failed: RPC-EOPNOTSUPP</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="ref://dpdk-bz/1102" notes="i40e: enabling Rx/Tx queue deferred start has no effect">
+        <results tags="net_i40e" key="ref://dpdk-bz/1102" notes="i40e: enabling Rx/Tx queue deferred start has no effect">
           <result value="FAILED">
             <verdict>Known but unexpected packets recevied</verdict>
           </result>
@@ -10167,7 +10167,7 @@
             <verdict>Failed to setup TxQ 0: EINVAL</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="ref://dpdk-bz/1102" notes="i40e: enabling Rx/Tx queue deferred start has no effect">
+        <results tags="net_i40e" key="ref://dpdk-bz/1102" notes="i40e: enabling Rx/Tx queue deferred start has no effect">
           <result value="FAILED">
             <verdict>The inactive queue(s) accepted the packet(s) for Tx</verdict>
             <verdict>The packet(s) really hit the wire</verdict>
@@ -10194,7 +10194,7 @@
             <verdict>Failed to setup TxQ 0: EINVAL</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="ref://dpdk-bz/1102" notes="i40e: enabling Rx/Tx queue deferred start has no effect">
+        <results tags="net_i40e" key="ref://dpdk-bz/1102" notes="i40e: enabling Rx/Tx queue deferred start has no effect">
           <result value="FAILED">
             <verdict>The inactive queue(s) accepted the packet(s) for Tx</verdict>
             <verdict>The packet(s) really hit the wire</verdict>
@@ -10221,7 +10221,7 @@
             <verdict>Failed to setup TxQ 0: EINVAL</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="ref://dpdk-bz/1102" notes="i40e: enabling Rx/Tx queue deferred start has no effect">
+        <results tags="net_i40e" key="ref://dpdk-bz/1102" notes="i40e: enabling Rx/Tx queue deferred start has no effect">
           <result value="FAILED">
             <verdict>The inactive queue(s) accepted the packet(s) for Tx</verdict>
             <verdict>The packet(s) really hit the wire</verdict>
@@ -10248,7 +10248,7 @@
             <verdict>Failed to setup TxQ 0: EINVAL</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="ref://dpdk-bz/1102" notes="i40e: enabling Rx/Tx queue deferred start has no effect">
+        <results tags="net_i40e" key="ref://dpdk-bz/1102" notes="i40e: enabling Rx/Tx queue deferred start has no effect">
           <result value="FAILED">
             <verdict>The inactive queue(s) accepted the packet(s) for Tx</verdict>
             <verdict>The packet(s) really hit the wire</verdict>
@@ -10272,7 +10272,7 @@
             <verdict>Runtime Rx queue setup is not supported by the device</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="ref://dpdk-bz/1110" notes="i40e runtime queue setup seems to be broken">
+        <results tags="net_i40e" key="ref://dpdk-bz/1110" notes="i40e runtime queue setup seems to be broken">
           <result value="FAILED">
             <verdict>Failed to start device with not setup Rx queue: RPC-EINVAL</verdict>
           </result>
@@ -10306,7 +10306,7 @@
             <verdict>Runtime Rx queue setup is not supported by the device</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -10345,7 +10345,7 @@
             <verdict>Runtime Rx queue setup is not supported by the device</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="ref://dpdk-bz/1110" notes="i40e runtime queue setup seems to be broken">
+        <results tags="net_i40e" key="ref://dpdk-bz/1110" notes="i40e runtime queue setup seems to be broken">
           <result value="FAILED">
             <verdict>Failed to start device with not setup Rx queue: RPC-EINVAL</verdict>
           </result>
@@ -10384,7 +10384,7 @@
             <verdict>Runtime Rx queue setup is not supported by the device</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
+        <results tags="net_i40e" key="FLOW-ISOLATE" notes="net/i40e does not support rte_flow_isolate()">
           <result value="SKIPPED">
             <verdict>rte_flow_isolate() RPC is unavailable</verdict>
           </result>
@@ -10431,7 +10431,7 @@
             <verdict>Runtime Rx queue setup is not supported by the device</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="ref://dpdk-bz/1110" notes="i40e runtime queue setup seems to be broken">
+        <results tags="net_i40e" key="ref://dpdk-bz/1110" notes="i40e runtime queue setup seems to be broken">
           <result value="FAILED">
             <verdict>Failed to start device with not setup Rx queue: RPC-EINVAL</verdict>
           </result>
@@ -10488,7 +10488,7 @@
             <verdict>Runtime Tx queue setup is not supported by the device</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="ref://dpdk-bz/1110" notes="i40e: runtime Rx/Tx queue setup is unusable">
+        <results tags="net_i40e" key="ref://dpdk-bz/1110" notes="i40e: runtime Rx/Tx queue setup is unusable">
           <result value="FAILED">
             <verdict>rte_eth_dev_start() failed: RPC-EINVAL</verdict>
           </result>
@@ -12348,7 +12348,7 @@
             <verdict>rte_eth_dev_configure() failed: RPC-EOPNOTSUPP</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="ref://dpdk-bz/1127" notes="i40e does retain RSS RETA on restart">
+        <results tags="net_i40e" key="ref://dpdk-bz/1127" notes="i40e does retain RSS RETA on restart">
           <result value="FAILED">
             <verdict>The RETA was changed after the port restarting</verdict>
           </result>
@@ -12374,7 +12374,7 @@
             <verdict>rte_eth_dev_configure() failed: RPC-EOPNOTSUPP</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="ref://dpdk-bz/1127" notes="i40e does retain RSS RETA on restart">
+        <results tags="net_i40e" key="ref://dpdk-bz/1127" notes="i40e does retain RSS RETA on restart">
           <result value="FAILED">
             <verdict>The RETA was changed after the port restarting</verdict>
           </result>
@@ -12400,7 +12400,7 @@
             <verdict>rte_eth_dev_configure() failed: RPC-EOPNOTSUPP</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="ref://dpdk-bz/1127" notes="i40e does retain RSS RETA on restart">
+        <results tags="net_i40e" key="ref://dpdk-bz/1127" notes="i40e does retain RSS RETA on restart">
           <result value="FAILED">
             <verdict>The RETA was changed after the port restarting</verdict>
           </result>
@@ -12431,7 +12431,7 @@
             <verdict>rte_eth_dev_configure() failed: RPC-EOPNOTSUPP</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="ref://dpdk-bz/1127" notes="i40e does retain RSS RETA on restart">
+        <results tags="net_i40e" key="ref://dpdk-bz/1127" notes="i40e does retain RSS RETA on restart">
           <result value="FAILED">
             <verdict>The RETA was changed after the port restarting</verdict>
           </result>
@@ -12546,7 +12546,7 @@
             <verdict>Extended statistic rx_brdcst_pkts is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="I40E-EXT-STATS" notes="i40e does not provide rx_pkts and rx_octets extended statistics">
+        <results tags="net_i40e" key="I40E-EXT-STATS" notes="i40e does not provide rx_pkts and rx_octets extended statistics">
           <result value="PASSED">
             <verdict>Extended statistic rx_pkts is not supported</verdict>
             <verdict>Extended statistic rx_octets is not supported</verdict>
@@ -12625,7 +12625,7 @@
             <verdict>Extended statistic rx_brdcst_pkts is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="I40E-EXT-STATS" notes="i40e does not provide rx_pkts and rx_octets extended statistics">
+        <results tags="net_i40e" key="I40E-EXT-STATS" notes="i40e does not provide rx_pkts and rx_octets extended statistics">
           <result value="PASSED">
             <verdict>Extended statistic rx_pkts is not supported</verdict>
             <verdict>Extended statistic rx_octets is not supported</verdict>
@@ -12704,7 +12704,7 @@
             <verdict>Extended statistic rx_brdcst_pkts is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="I40E-EXT-STATS" notes="i40e does not provide rx_pkts and rx_octets extended statistics">
+        <results tags="net_i40e" key="I40E-EXT-STATS" notes="i40e does not provide rx_pkts and rx_octets extended statistics">
           <result value="PASSED">
             <verdict>Extended statistic rx_pkts is not supported</verdict>
             <verdict>Extended statistic rx_octets is not supported</verdict>
@@ -12783,7 +12783,7 @@
             <verdict>Extended statistic rx_brdcst_pkts is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="I40E-EXT-STATS" notes="i40e does not provide rx_pkts and rx_octets extended statistics">
+        <results tags="net_i40e" key="I40E-EXT-STATS" notes="i40e does not provide rx_pkts and rx_octets extended statistics">
           <result value="PASSED">
             <verdict>Extended statistic rx_pkts is not supported</verdict>
             <verdict>Extended statistic rx_octets is not supported</verdict>
@@ -12862,7 +12862,7 @@
             <verdict>Extended statistic rx_brdcst_pkts is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="I40E-EXT-STATS" notes="i40e does not provide rx_pkts and rx_octets extended statistics">
+        <results tags="net_i40e" key="I40E-EXT-STATS" notes="i40e does not provide rx_pkts and rx_octets extended statistics">
           <result value="PASSED">
             <verdict>Extended statistic rx_pkts is not supported</verdict>
             <verdict>Extended statistic rx_octets is not supported</verdict>
@@ -12946,7 +12946,7 @@
             <verdict>Extended statistic rx_brdcst_pkts is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="I40E-EXT-STATS" notes="i40e does not provide rx_pkts and rx_octets extended statistics">
+        <results tags="net_i40e" key="I40E-EXT-STATS" notes="i40e does not provide rx_pkts and rx_octets extended statistics">
           <result value="PASSED">
             <verdict>Extended statistic rx_pkts is not supported</verdict>
             <verdict>Extended statistic rx_octets is not supported</verdict>
@@ -13035,7 +13035,7 @@
             <verdict>Extended statistic rx_brdcst_pkts is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="I40E-EXT-STATS" notes="i40e does not provide rx_pkts and rx_octets extended statistics">
+        <results tags="net_i40e" key="I40E-EXT-STATS" notes="i40e does not provide rx_pkts and rx_octets extended statistics">
           <result value="PASSED">
             <verdict>Extended statistic rx_pkts is not supported</verdict>
             <verdict>Extended statistic rx_octets is not supported</verdict>
@@ -13124,7 +13124,7 @@
             <verdict>Extended statistic rx_brdcst_pkts is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="I40E-EXT-STATS" notes="i40e does not provide rx_pkts and rx_octets extended statistics">
+        <results tags="net_i40e" key="I40E-EXT-STATS" notes="i40e does not provide rx_pkts and rx_octets extended statistics">
           <result value="PASSED">
             <verdict>Extended statistic rx_pkts is not supported</verdict>
             <verdict>Extended statistic rx_octets is not supported</verdict>
@@ -13213,7 +13213,7 @@
             <verdict>Extended statistic rx_brdcst_pkts is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="I40E-EXT-STATS" notes="i40e does not provide rx_pkts and rx_octets extended statistics">
+        <results tags="net_i40e" key="I40E-EXT-STATS" notes="i40e does not provide rx_pkts and rx_octets extended statistics">
           <result value="PASSED">
             <verdict>Extended statistic rx_pkts is not supported</verdict>
             <verdict>Extended statistic rx_octets is not supported</verdict>
@@ -13302,7 +13302,7 @@
             <verdict>Extended statistic rx_brdcst_pkts is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="I40E-EXT-STATS" notes="i40e does not provide rx_pkts and rx_octets extended statistics">
+        <results tags="net_i40e" key="I40E-EXT-STATS" notes="i40e does not provide rx_pkts and rx_octets extended statistics">
           <result value="PASSED">
             <verdict>Extended statistic rx_pkts is not supported</verdict>
             <verdict>Extended statistic rx_octets is not supported</verdict>
@@ -13391,7 +13391,7 @@
             <verdict>Extended statistic rx_brdcst_pkts is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="I40E-EXT-STATS" notes="i40e does not provide rx_pkts and rx_octets extended statistics">
+        <results tags="net_i40e" key="I40E-EXT-STATS" notes="i40e does not provide rx_pkts and rx_octets extended statistics">
           <result value="PASSED">
             <verdict>Extended statistic rx_pkts is not supported</verdict>
             <verdict>Extended statistic rx_octets is not supported</verdict>
@@ -13485,7 +13485,7 @@
             <verdict>Extended statistic rx_brdcst_pkts is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="I40E-EXT-STATS" notes="i40e does not provide rx_pkts and rx_octets extended statistics">
+        <results tags="net_i40e" key="I40E-EXT-STATS" notes="i40e does not provide rx_pkts and rx_octets extended statistics">
           <result value="PASSED">
             <verdict>Extended statistic rx_pkts is not supported</verdict>
             <verdict>Extended statistic rx_octets is not supported</verdict>
@@ -13564,7 +13564,7 @@
             <verdict>Extended statistic rx_brdcst_pkts is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="I40E-EXT-STATS" notes="i40e does not provide rx_pkts and rx_octets extended statistics">
+        <results tags="net_i40e" key="I40E-EXT-STATS" notes="i40e does not provide rx_pkts and rx_octets extended statistics">
           <result value="PASSED">
             <verdict>Extended statistic rx_pkts is not supported</verdict>
             <verdict>Extended statistic rx_octets is not supported</verdict>
@@ -13643,7 +13643,7 @@
             <verdict>Extended statistic rx_brdcst_pkts is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="I40E-EXT-STATS" notes="i40e does not provide rx_pkts and rx_octets extended statistics">
+        <results tags="net_i40e" key="I40E-EXT-STATS" notes="i40e does not provide rx_pkts and rx_octets extended statistics">
           <result value="PASSED">
             <verdict>Extended statistic rx_pkts is not supported</verdict>
             <verdict>Extended statistic rx_octets is not supported</verdict>
@@ -13722,7 +13722,7 @@
             <verdict>Extended statistic rx_brdcst_pkts is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="I40E-EXT-STATS" notes="i40e does not provide rx_pkts and rx_octets extended statistics">
+        <results tags="net_i40e" key="I40E-EXT-STATS" notes="i40e does not provide rx_pkts and rx_octets extended statistics">
           <result value="PASSED">
             <verdict>Extended statistic rx_pkts is not supported</verdict>
             <verdict>Extended statistic rx_octets is not supported</verdict>
@@ -13801,7 +13801,7 @@
             <verdict>Extended statistic rx_brdcst_pkts is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="I40E-EXT-STATS" notes="i40e does not provide rx_pkts and rx_octets extended statistics">
+        <results tags="net_i40e" key="I40E-EXT-STATS" notes="i40e does not provide rx_pkts and rx_octets extended statistics">
           <result value="PASSED">
             <verdict>Extended statistic rx_pkts is not supported</verdict>
             <verdict>Extended statistic rx_octets is not supported</verdict>
@@ -13880,7 +13880,7 @@
             <verdict>Extended statistic rx_brdcst_pkts is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="I40E-EXT-STATS" notes="i40e does not provide rx_pkts and rx_octets extended statistics">
+        <results tags="net_i40e" key="I40E-EXT-STATS" notes="i40e does not provide rx_pkts and rx_octets extended statistics">
           <result value="PASSED">
             <verdict>Extended statistic rx_pkts is not supported</verdict>
             <verdict>Extended statistic rx_octets is not supported</verdict>
@@ -13964,7 +13964,7 @@
             <verdict>Extended statistic rx_brdcst_pkts is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="I40E-EXT-STATS" notes="i40e does not provide rx_pkts and rx_octets extended statistics">
+        <results tags="net_i40e" key="I40E-EXT-STATS" notes="i40e does not provide rx_pkts and rx_octets extended statistics">
           <result value="PASSED">
             <verdict>Extended statistic rx_pkts is not supported</verdict>
             <verdict>Extended statistic rx_octets is not supported</verdict>
@@ -14058,7 +14058,7 @@
             <verdict>Extended statistic tx_brdcst_pkts is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="I40E-EXT-STATS" notes="i40e does not provide tx_pkts and tx_octets extended statistics">
+        <results tags="net_i40e" key="I40E-EXT-STATS" notes="i40e does not provide tx_pkts and tx_octets extended statistics">
           <result value="PASSED">
             <verdict>Extended statistic tx_pkts is not supported</verdict>
             <verdict>Extended statistic tx_octets is not supported</verdict>
@@ -14148,7 +14148,7 @@
             <verdict>Extended statistic tx_brdcst_pkts is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="I40E-EXT-STATS" notes="i40e does not provide tx_pkts and tx_octets extended statistics">
+        <results tags="net_i40e" key="I40E-EXT-STATS" notes="i40e does not provide tx_pkts and tx_octets extended statistics">
           <result value="PASSED">
             <verdict>Extended statistic tx_pkts is not supported</verdict>
             <verdict>Extended statistic tx_octets is not supported</verdict>
@@ -14238,7 +14238,7 @@
             <verdict>Extended statistic tx_brdcst_pkts is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="I40E-EXT-STATS" notes="i40e does not provide tx_pkts and tx_octets extended statistics">
+        <results tags="net_i40e" key="I40E-EXT-STATS" notes="i40e does not provide tx_pkts and tx_octets extended statistics">
           <result value="PASSED">
             <verdict>Extended statistic tx_pkts is not supported</verdict>
             <verdict>Extended statistic tx_octets is not supported</verdict>
@@ -14328,7 +14328,7 @@
             <verdict>Extended statistic tx_brdcst_pkts is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="I40E-EXT-STATS" notes="i40e does not provide tx_pkts and tx_octets extended statistics">
+        <results tags="net_i40e" key="I40E-EXT-STATS" notes="i40e does not provide tx_pkts and tx_octets extended statistics">
           <result value="PASSED">
             <verdict>Extended statistic tx_pkts is not supported</verdict>
             <verdict>Extended statistic tx_octets is not supported</verdict>
@@ -14418,7 +14418,7 @@
             <verdict>Extended statistic tx_brdcst_pkts is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="I40E-EXT-STATS" notes="i40e does not provide tx_pkts and tx_octets extended statistics">
+        <results tags="net_i40e" key="I40E-EXT-STATS" notes="i40e does not provide tx_pkts and tx_octets extended statistics">
           <result value="PASSED">
             <verdict>Extended statistic tx_pkts is not supported</verdict>
             <verdict>Extended statistic tx_octets is not supported</verdict>
@@ -14508,7 +14508,7 @@
             <verdict>Extended statistic tx_brdcst_pkts is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="I40E-EXT-STATS" notes="i40e does not provide tx_pkts and tx_octets extended statistics">
+        <results tags="net_i40e" key="I40E-EXT-STATS" notes="i40e does not provide tx_pkts and tx_octets extended statistics">
           <result value="PASSED">
             <verdict>Extended statistic tx_pkts is not supported</verdict>
             <verdict>Extended statistic tx_octets is not supported</verdict>
@@ -14598,7 +14598,7 @@
             <verdict>Extended statistic tx_brdcst_pkts is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="I40E-EXT-STATS" notes="i40e does not provide tx_pkts and tx_octets extended statistics">
+        <results tags="net_i40e" key="I40E-EXT-STATS" notes="i40e does not provide tx_pkts and tx_octets extended statistics">
           <result value="PASSED">
             <verdict>Extended statistic tx_pkts is not supported</verdict>
             <verdict>Extended statistic tx_octets is not supported</verdict>
@@ -14688,7 +14688,7 @@
             <verdict>Extended statistic tx_brdcst_pkts is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="I40E-EXT-STATS" notes="i40e does not provide tx_pkts and tx_octets extended statistics">
+        <results tags="net_i40e" key="I40E-EXT-STATS" notes="i40e does not provide tx_pkts and tx_octets extended statistics">
           <result value="PASSED">
             <verdict>Extended statistic tx_pkts is not supported</verdict>
             <verdict>Extended statistic tx_octets is not supported</verdict>
@@ -14778,7 +14778,7 @@
             <verdict>Extended statistic tx_brdcst_pkts is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="I40E-EXT-STATS" notes="i40e does not provide tx_pkts and tx_octets extended statistics">
+        <results tags="net_i40e" key="I40E-EXT-STATS" notes="i40e does not provide tx_pkts and tx_octets extended statistics">
           <result value="PASSED">
             <verdict>Extended statistic tx_pkts is not supported</verdict>
             <verdict>Extended statistic tx_octets is not supported</verdict>
@@ -14868,7 +14868,7 @@
             <verdict>Extended statistic tx_brdcst_pkts is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="I40E-EXT-STATS" notes="i40e does not provide tx_pkts and tx_octets extended statistics">
+        <results tags="net_i40e" key="I40E-EXT-STATS" notes="i40e does not provide tx_pkts and tx_octets extended statistics">
           <result value="PASSED">
             <verdict>Extended statistic tx_pkts is not supported</verdict>
             <verdict>Extended statistic tx_octets is not supported</verdict>
@@ -14958,7 +14958,7 @@
             <verdict>Extended statistic tx_brdcst_pkts is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="I40E-EXT-STATS" notes="i40e does not provide tx_pkts and tx_octets extended statistics">
+        <results tags="net_i40e" key="I40E-EXT-STATS" notes="i40e does not provide tx_pkts and tx_octets extended statistics">
           <result value="PASSED">
             <verdict>Extended statistic tx_pkts is not supported</verdict>
             <verdict>Extended statistic tx_octets is not supported</verdict>
@@ -15048,7 +15048,7 @@
             <verdict>Extended statistic tx_brdcst_pkts is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="I40E-EXT-STATS" notes="i40e does not provide tx_pkts and tx_octets extended statistics">
+        <results tags="net_i40e" key="I40E-EXT-STATS" notes="i40e does not provide tx_pkts and tx_octets extended statistics">
           <result value="PASSED">
             <verdict>Extended statistic tx_pkts is not supported</verdict>
             <verdict>Extended statistic tx_octets is not supported</verdict>
@@ -15138,7 +15138,7 @@
             <verdict>Extended statistic tx_brdcst_pkts is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="I40E-EXT-STATS" notes="i40e does not provide tx_pkts and tx_octets extended statistics">
+        <results tags="net_i40e" key="I40E-EXT-STATS" notes="i40e does not provide tx_pkts and tx_octets extended statistics">
           <result value="PASSED">
             <verdict>Extended statistic tx_pkts is not supported</verdict>
             <verdict>Extended statistic tx_octets is not supported</verdict>
@@ -15228,7 +15228,7 @@
             <verdict>Extended statistic tx_brdcst_pkts is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="I40E-EXT-STATS" notes="i40e does not provide tx_pkts and tx_octets extended statistics">
+        <results tags="net_i40e" key="I40E-EXT-STATS" notes="i40e does not provide tx_pkts and tx_octets extended statistics">
           <result value="PASSED">
             <verdict>Extended statistic tx_pkts is not supported</verdict>
             <verdict>Extended statistic tx_octets is not supported</verdict>
@@ -15318,7 +15318,7 @@
             <verdict>Extended statistic tx_brdcst_pkts is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="I40E-EXT-STATS" notes="i40e does not provide tx_pkts and tx_octets extended statistics">
+        <results tags="net_i40e" key="I40E-EXT-STATS" notes="i40e does not provide tx_pkts and tx_octets extended statistics">
           <result value="PASSED">
             <verdict>Extended statistic tx_pkts is not supported</verdict>
             <verdict>Extended statistic tx_octets is not supported</verdict>
@@ -15413,7 +15413,7 @@
             <verdict>Extended statistic tx_brdcst_pkts is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="I40E-EXT-STATS" notes="i40e does not provide tx_pkts and tx_octets extended statistics">
+        <results tags="net_i40e" key="I40E-EXT-STATS" notes="i40e does not provide tx_pkts and tx_octets extended statistics">
           <result value="PASSED">
             <verdict>Extended statistic tx_pkts is not supported</verdict>
             <verdict>Extended statistic tx_octets is not supported</verdict>
@@ -15508,7 +15508,7 @@
             <verdict>Extended statistic tx_brdcst_pkts is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="I40E-EXT-STATS" notes="i40e does not provide tx_pkts and tx_octets extended statistics">
+        <results tags="net_i40e" key="I40E-EXT-STATS" notes="i40e does not provide tx_pkts and tx_octets extended statistics">
           <result value="PASSED">
             <verdict>Extended statistic tx_pkts is not supported</verdict>
             <verdict>Extended statistic tx_octets is not supported</verdict>
@@ -15603,7 +15603,7 @@
             <verdict>Extended statistic tx_brdcst_pkts is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="I40E-EXT-STATS" notes="i40e does not provide tx_pkts and tx_octets extended statistics">
+        <results tags="net_i40e" key="I40E-EXT-STATS" notes="i40e does not provide tx_pkts and tx_octets extended statistics">
           <result value="PASSED">
             <verdict>Extended statistic tx_pkts is not supported</verdict>
             <verdict>Extended statistic tx_octets is not supported</verdict>
@@ -15745,7 +15745,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="NO-TEREDO" notes="Intel X710 with i40e supports VXLAN only">
+        <results tags="net_i40e" key="NO-TEREDO" notes="Intel X710 with i40e supports VXLAN only">
           <result value="SKIPPED">
             <verdict>The tunnel type is unsupported</verdict>
           </result>
@@ -15824,7 +15824,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="NO-GENEVE" notes="Intel X710 with i40e supports VXLAN only">
+        <results tags="net_i40e" key="NO-GENEVE" notes="Intel X710 with i40e supports VXLAN only">
           <result value="SKIPPED">
             <verdict>The tunnel type is unsupported</verdict>
           </result>
@@ -17627,7 +17627,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -17693,7 +17693,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -17759,7 +17759,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -17825,7 +17825,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -17891,7 +17891,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -17959,7 +17959,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -18027,7 +18027,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -18095,7 +18095,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -18163,7 +18163,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -18231,7 +18231,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -18297,7 +18297,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -18363,7 +18363,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -18429,7 +18429,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -18495,7 +18495,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -18563,7 +18563,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -18631,7 +18631,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -18699,7 +18699,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -18767,7 +18767,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -18835,7 +18835,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -18900,7 +18900,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -18965,7 +18965,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -19030,7 +19030,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -19095,7 +19095,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -19162,7 +19162,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -19229,7 +19229,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -19296,7 +19296,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -19363,7 +19363,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -22565,7 +22565,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -22631,7 +22631,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -22697,7 +22697,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -22763,7 +22763,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -22829,7 +22829,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -22897,7 +22897,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -22965,7 +22965,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -23033,7 +23033,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -23101,7 +23101,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -23169,7 +23169,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -23235,7 +23235,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -23301,7 +23301,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -23367,7 +23367,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -23433,7 +23433,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -23501,7 +23501,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -23569,7 +23569,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -23637,7 +23637,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -23705,7 +23705,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -23773,7 +23773,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -23838,7 +23838,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -23903,7 +23903,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -23968,7 +23968,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -24033,7 +24033,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -24100,7 +24100,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -24167,7 +24167,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -24234,7 +24234,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -24301,7 +24301,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -25881,7 +25881,7 @@
             <verdict>Set list of multicast addresses operation is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="SET-MC-ADDR-LIST" notes="net/i40e does not provide set_mc_addr_list driver operation">
+        <results tags="net_i40e" key="SET-MC-ADDR-LIST" notes="net/i40e does not provide set_mc_addr_list driver operation">
           <result value="SKIPPED">
             <verdict>Set list of multicast addresses operation is not supported</verdict>
           </result>
@@ -25909,7 +25909,7 @@
             <verdict>Set list of multicast addresses operation is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="SET-MC-ADDR-LIST" notes="net/i40e does not provide set_mc_addr_list driver operation">
+        <results tags="net_i40e" key="SET-MC-ADDR-LIST" notes="net/i40e does not provide set_mc_addr_list driver operation">
           <result value="SKIPPED">
             <verdict>Set list of multicast addresses operation is not supported</verdict>
           </result>
@@ -25932,7 +25932,7 @@
             <verdict>Set list of multicast addresses operation is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="SET-MC-ADDR-LIST" notes="net/i40e does not provide set_mc_addr_list driver operation">
+        <results tags="net_i40e" key="SET-MC-ADDR-LIST" notes="net/i40e does not provide set_mc_addr_list driver operation">
           <result value="SKIPPED">
             <verdict>Set list of multicast addresses operation is not supported</verdict>
           </result>
@@ -25955,7 +25955,7 @@
             <verdict>Set list of multicast addresses operation is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="SET-MC-ADDR-LIST" notes="net/i40e does not provide set_mc_addr_list driver operation">
+        <results tags="net_i40e" key="SET-MC-ADDR-LIST" notes="net/i40e does not provide set_mc_addr_list driver operation">
           <result value="SKIPPED">
             <verdict>Set list of multicast addresses operation is not supported</verdict>
           </result>
@@ -25978,7 +25978,7 @@
             <verdict>Set list of multicast addresses operation is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="SET-MC-ADDR-LIST" notes="net/i40e does not provide set_mc_addr_list driver operation">
+        <results tags="net_i40e" key="SET-MC-ADDR-LIST" notes="net/i40e does not provide set_mc_addr_list driver operation">
           <result value="SKIPPED">
             <verdict>Set list of multicast addresses operation is not supported</verdict>
           </result>
@@ -26001,7 +26001,7 @@
             <verdict>Set list of multicast addresses operation is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="SET-MC-ADDR-LIST" notes="net/i40e does not provide set_mc_addr_list driver operation">
+        <results tags="net_i40e" key="SET-MC-ADDR-LIST" notes="net/i40e does not provide set_mc_addr_list driver operation">
           <result value="SKIPPED">
             <verdict>Set list of multicast addresses operation is not supported</verdict>
           </result>
@@ -26024,7 +26024,7 @@
             <verdict>Set list of multicast addresses operation is not supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="SET-MC-ADDR-LIST" notes="net/i40e does not provide set_mc_addr_list driver operation">
+        <results tags="net_i40e" key="SET-MC-ADDR-LIST" notes="net/i40e does not provide set_mc_addr_list driver operation">
           <result value="SKIPPED">
             <verdict>Set list of multicast addresses operation is not supported</verdict>
           </result>
@@ -26186,7 +26186,7 @@
             <verdict>Different info on state: STARTED</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="ref://dpdk-bz/1132" notes="i40e for Intel X710 recommends ring size based on link speed which is updated on start">
+        <results tags="net_i40e" key="ref://dpdk-bz/1132" notes="i40e for Intel X710 recommends ring size based on link speed which is updated on start">
           <result value="FAILED">
             <verdict>default_rxportconf's fields ring_size don't match</verdict>
             <verdict>Different info on state: STARTED</verdict>
@@ -26208,7 +26208,7 @@
             <verdict>Different info on state: STARTED</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="ref://dpdk-bz/1132" notes="i40e for Intel X710 recommends ring size based on link speed which is updated on start">
+        <results tags="net_i40e" key="ref://dpdk-bz/1132" notes="i40e for Intel X710 recommends ring size based on link speed which is updated on start">
           <result value="FAILED">
             <verdict>default_rxportconf's fields ring_size don't match</verdict>
             <verdict>Different info on state: STARTED</verdict>
@@ -26230,7 +26230,7 @@
             <verdict>Different info on state: STARTED</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="ref://dpdk-bz/1132" notes="i40e for Intel X710 recommends ring size based on link speed which is updated on start">
+        <results tags="net_i40e" key="ref://dpdk-bz/1132" notes="i40e for Intel X710 recommends ring size based on link speed which is updated on start">
           <result value="FAILED">
             <verdict>default_rxportconf's fields ring_size don't match</verdict>
             <verdict>Different info on state: STARTED</verdict>
@@ -26252,7 +26252,7 @@
             <verdict>Different info on state: STARTED</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="ref://dpdk-bz/1132" notes="i40e for Intel X710 recommends ring size based on link speed which is updated on start">
+        <results tags="net_i40e" key="ref://dpdk-bz/1132" notes="i40e for Intel X710 recommends ring size based on link speed which is updated on start">
           <result value="FAILED">
             <verdict>default_rxportconf's fields ring_size don't match</verdict>
             <verdict>Different info on state: STARTED</verdict>
@@ -26274,7 +26274,7 @@
             <verdict>Different info on state: STARTED</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="ref://dpdk-bz/1132" notes="i40e for Intel X710 recommends ring size based on link speed which is updated on start">
+        <results tags="net_i40e" key="ref://dpdk-bz/1132" notes="i40e for Intel X710 recommends ring size based on link speed which is updated on start">
           <result value="FAILED">
             <verdict>default_rxportconf's fields ring_size don't match</verdict>
             <verdict>Different info on state: STARTED</verdict>
@@ -26318,7 +26318,7 @@
             <verdict>Correct RSS configuration has been rejected on configuration stage</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="ref://dpdk-bz/1113" notes="i40e: device configure ignores RSS key in rx_adv_conf">
+        <results tags="net_i40e" key="ref://dpdk-bz/1113" notes="i40e: device configure ignores RSS key in rx_adv_conf">
           <result value="FAILED">
             <verdict>Bogus RSS key size has been accepted</verdict>
           </result>
@@ -26700,7 +26700,7 @@
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for tagged packet when VLAN stripping is supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
+        <results tags="net_i40e" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
           <result value="PASSED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for tagged packet when VLAN stripping is supported</verdict>
           </result>
@@ -26717,7 +26717,7 @@
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for tagged packet when VLAN stripping is supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
+        <results tags="net_i40e" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
           <result value="PASSED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for tagged packet when VLAN stripping is supported</verdict>
           </result>
@@ -26739,7 +26739,7 @@
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for tagged packet when VLAN stripping is supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
+        <results tags="net_i40e" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
           <result value="PASSED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for tagged packet when VLAN stripping is supported</verdict>
           </result>
@@ -26761,7 +26761,7 @@
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for tagged packet when VLAN stripping is supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
+        <results tags="net_i40e" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
           <result value="PASSED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for tagged packet when VLAN stripping is supported</verdict>
           </result>
@@ -26783,7 +26783,7 @@
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for tagged packet when VLAN stripping is supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
+        <results tags="net_i40e" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
           <result value="PASSED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for tagged packet when VLAN stripping is supported</verdict>
           </result>
@@ -26805,7 +26805,7 @@
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for tagged packet when VLAN stripping is supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
+        <results tags="net_i40e" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
           <result value="PASSED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for tagged packet when VLAN stripping is supported</verdict>
           </result>
@@ -26827,7 +26827,7 @@
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for tagged packet when VLAN stripping is supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
+        <results tags="net_i40e" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
           <result value="PASSED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for tagged packet when VLAN stripping is supported</verdict>
           </result>
@@ -26849,7 +26849,7 @@
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
+        <results tags="net_i40e" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
           <result value="FAILED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
             <verdict>RTE_MBUF_F_RX_QINQ flag is not set for double-tagged packet when QinQ stripping is supported</verdict>
@@ -26872,7 +26872,7 @@
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
+        <results tags="net_i40e" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
           <result value="FAILED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
             <verdict>RTE_MBUF_F_RX_QINQ flag is not set for double-tagged packet when QinQ stripping is supported</verdict>
@@ -26895,7 +26895,7 @@
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
+        <results tags="net_i40e" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
           <result value="FAILED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
             <verdict>RTE_MBUF_F_RX_QINQ flag is not set for double-tagged packet when QinQ stripping is supported</verdict>
@@ -26918,7 +26918,7 @@
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
+        <results tags="net_i40e" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
           <result value="FAILED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
             <verdict>RTE_MBUF_F_RX_QINQ flag is not set for double-tagged packet when QinQ stripping is supported</verdict>
@@ -26941,7 +26941,7 @@
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
+        <results tags="net_i40e" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
           <result value="FAILED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
             <verdict>RTE_MBUF_F_RX_QINQ flag is not set for double-tagged packet when QinQ stripping is supported</verdict>
@@ -26964,7 +26964,7 @@
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
+        <results tags="net_i40e" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
           <result value="FAILED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
             <verdict>RTE_MBUF_F_RX_QINQ flag is not set for double-tagged packet when QinQ stripping is supported</verdict>
@@ -26987,7 +26987,7 @@
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
+        <results tags="net_i40e" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
           <result value="FAILED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
             <verdict>RTE_MBUF_F_RX_QINQ flag is not set for double-tagged packet when QinQ stripping is supported</verdict>
@@ -27010,7 +27010,7 @@
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for tagged packet when VLAN stripping is supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
+        <results tags="net_i40e" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
           <result value="PASSED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for tagged packet when VLAN stripping is supported</verdict>
           </result>
@@ -27032,7 +27032,7 @@
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
+        <results tags="net_i40e" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
           <result value="FAILED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
             <verdict>RTE_MBUF_F_RX_QINQ flag is not set for double-tagged packet when QinQ stripping is supported</verdict>
@@ -27126,7 +27126,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
+        <results tags="net_i40e" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
           <result value="PASSED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for tagged packet when VLAN stripping is supported</verdict>
           </result>
@@ -27173,7 +27173,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -27210,7 +27210,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
+        <results tags="net_i40e" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
           <result value="FAILED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
             <verdict>RTE_MBUF_F_RX_QINQ flag is not set for double-tagged packet when QinQ stripping is supported</verdict>
@@ -27263,7 +27263,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -27675,7 +27675,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -27759,7 +27759,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -28196,7 +28196,7 @@
             <verdict>QinQ strip is requested but not available</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -28287,7 +28287,7 @@
             <verdict>QinQ strip is requested but not available</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -28562,7 +28562,7 @@
             <verdict>QinQ strip is requested but not available</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
+        <results tags="net_i40e" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
           <result value="PASSED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for tagged packet when VLAN stripping is supported</verdict>
           </result>
@@ -28594,7 +28594,7 @@
             <verdict>QinQ strip is requested but not available</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
+        <results tags="net_i40e" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
           <result value="PASSED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for tagged packet when VLAN stripping is supported</verdict>
           </result>
@@ -28626,7 +28626,7 @@
             <verdict>QinQ strip is requested but not available</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
+        <results tags="net_i40e" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
           <result value="PASSED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for tagged packet when VLAN stripping is supported</verdict>
           </result>
@@ -28658,7 +28658,7 @@
             <verdict>QinQ strip is requested but not available</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
+        <results tags="net_i40e" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
           <result value="PASSED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for tagged packet when VLAN stripping is supported</verdict>
           </result>
@@ -28690,7 +28690,7 @@
             <verdict>QinQ strip is requested but not available</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
+        <results tags="net_i40e" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
           <result value="PASSED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for tagged packet when VLAN stripping is supported</verdict>
           </result>
@@ -28722,7 +28722,7 @@
             <verdict>QinQ strip is requested but not available</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
+        <results tags="net_i40e" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
           <result value="PASSED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for tagged packet when VLAN stripping is supported</verdict>
           </result>
@@ -28754,7 +28754,7 @@
             <verdict>QinQ strip is requested but not available</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
+        <results tags="net_i40e" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
           <result value="PASSED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for tagged packet when VLAN stripping is supported</verdict>
           </result>
@@ -28975,7 +28975,7 @@
             <verdict>QinQ strip is requested but not available</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
+        <results tags="net_i40e" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
           <result value="PASSED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for tagged packet when VLAN stripping is supported</verdict>
           </result>
@@ -29012,7 +29012,7 @@
             <verdict>QinQ strip is requested but not available</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -29044,7 +29044,7 @@
             <verdict>QinQ strip is requested but not available</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
+        <results tags="net_i40e" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
           <result value="PASSED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for tagged packet when VLAN stripping is supported</verdict>
           </result>
@@ -29108,7 +29108,7 @@
             <verdict>QinQ strip is requested but not available</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -29386,7 +29386,7 @@
             <verdict>Rx queue set up failed due to violated descriptors limits</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="RX-DESCS-MIN" notes="net/i40e has minimum number of Rx descriptors 64">
+        <results tags="net_i40e" key="RX-DESCS-MIN" notes="net/i40e has minimum number of Rx descriptors 64">
           <result value="SKIPPED">
             <verdict>Rx queue set up failed due to violated descriptors limits</verdict>
           </result>
@@ -29419,7 +29419,7 @@
             <verdict>8 received packets match initially requested number of Rx descriptors</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="RX-DESCS-MIN" notes="net/i40e has minimum number of Rx descriptors 64">
+        <results tags="net_i40e" key="RX-DESCS-MIN" notes="net/i40e has minimum number of Rx descriptors 64">
           <result value="SKIPPED">
             <verdict>Rx queue set up failed due to violated descriptors limits</verdict>
           </result>
@@ -29447,7 +29447,7 @@
             <verdict>32 received packets match initially requested number of Rx descriptors</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="RX-DESCS-MIN" notes="net/i40e has minimum number of Rx descriptors 64">
+        <results tags="net_i40e" key="RX-DESCS-MIN" notes="net/i40e has minimum number of Rx descriptors 64">
           <result value="SKIPPED">
             <verdict>Rx queue set up failed due to violated descriptors limits</verdict>
           </result>
@@ -29458,7 +29458,7 @@
         <arg name="template"/>
         <arg name="nb_rxd">64</arg>
         <notes/>
-        <results tags="pci-8086-1572|pci-8086-1583" key="RX-DESCS-9-UNUSED" notes="net/i40e keeps 9 Rx descriptors unused">
+        <results tags="net_i40e" key="RX-DESCS-9-UNUSED" notes="net/i40e keeps 9 Rx descriptors unused">
           <result value="PASSED">
             <verdict>Received 9 packets less than initially requested number of Rx descriptors</verdict>
           </result>
@@ -29491,7 +29491,7 @@
             <verdict>Received 64 packets less than initially requested number of Rx descriptors</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="RX-DESCS-9-UNUSED" notes="net/i40e keeps 9 Rx descriptors unused">
+        <results tags="net_i40e" key="RX-DESCS-9-UNUSED" notes="net/i40e keeps 9 Rx descriptors unused">
           <result value="PASSED">
             <verdict>Received 9 packets less than initially requested number of Rx descriptors</verdict>
           </result>
@@ -29524,7 +29524,7 @@
             <verdict>Received 192 packets less than initially requested number of Rx descriptors</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="RX-DESCS-9-UNUSED" notes="net/i40e keeps 9 Rx descriptors unused">
+        <results tags="net_i40e" key="RX-DESCS-9-UNUSED" notes="net/i40e keeps 9 Rx descriptors unused">
           <result value="PASSED">
             <verdict>Received 9 packets less than initially requested number of Rx descriptors</verdict>
           </result>
@@ -29579,7 +29579,7 @@
             <verdict>496 received packets match initially requested number of Rx descriptors</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="RX-DESCS-ALIGN" notes="net/i40e requires Rx descriptors number to be aligned">
+        <results tags="net_i40e" key="RX-DESCS-ALIGN" notes="net/i40e requires Rx descriptors number to be aligned">
           <result value="SKIPPED">
             <verdict>Rx queue set up failed due to violated descriptors limits</verdict>
           </result>
@@ -29611,7 +29611,7 @@
             <verdict>Rx queue set up failed due to violated descriptors limits</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="RX-DESCS-ALIGN" notes="net/i40e requires Rx descriptors number to be aligned">
+        <results tags="net_i40e" key="RX-DESCS-ALIGN" notes="net/i40e requires Rx descriptors number to be aligned">
           <result value="SKIPPED">
             <verdict>Rx queue set up failed due to violated descriptors limits</verdict>
           </result>
@@ -29627,7 +29627,7 @@
             <verdict>Received 448 packets less than initially requested number of Rx descriptors</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="RX-DESCS-9-UNUSED" notes="net/i40e keeps 9 Rx descriptors unused">
+        <results tags="net_i40e" key="RX-DESCS-9-UNUSED" notes="net/i40e keeps 9 Rx descriptors unused">
           <result value="PASSED">
             <verdict>Received 9 packets less than initially requested number of Rx descriptors</verdict>
           </result>
@@ -29676,7 +29676,7 @@
             <verdict>1000 received packets match initially requested number of Rx descriptors</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="RX-DESCS-ALIGN" notes="net/i40e requires Rx descriptors number to be aligned">
+        <results tags="net_i40e" key="RX-DESCS-ALIGN" notes="net/i40e requires Rx descriptors number to be aligned">
           <result value="SKIPPED">
             <verdict>Rx queue set up failed due to violated descriptors limits</verdict>
           </result>
@@ -29692,7 +29692,7 @@
             <verdict>Received 960 packets less than initially requested number of Rx descriptors</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="RX-DESCS-9-UNUSED" notes="net/i40e keeps 9 Rx descriptors unused">
+        <results tags="net_i40e" key="RX-DESCS-9-UNUSED" notes="net/i40e keeps 9 Rx descriptors unused">
           <result value="PASSED">
             <verdict>Received 9 packets less than initially requested number of Rx descriptors</verdict>
           </result>
@@ -29718,7 +29718,7 @@
             <verdict>Received 1984 packets less than initially requested number of Rx descriptors</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="RX-DESCS-9-UNUSED" notes="net/i40e keeps 9 Rx descriptors unused">
+        <results tags="net_i40e" key="RX-DESCS-9-UNUSED" notes="net/i40e keeps 9 Rx descriptors unused">
           <result value="PASSED">
             <verdict>Received 9 packets less than initially requested number of Rx descriptors</verdict>
           </result>
@@ -29750,7 +29750,7 @@
             <verdict>Number of received packets matches effective number of Rx descriptors</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="RX-DESCS-9-UNUSED" notes="net/i40e keeps 9 Rx descriptors unused">
+        <results tags="net_i40e" key="RX-DESCS-9-UNUSED" notes="net/i40e keeps 9 Rx descriptors unused">
           <result value="PASSED">
             <verdict>Received 9 packets less than initially requested number of Rx descriptors</verdict>
           </result>
@@ -29801,7 +29801,7 @@
             <verdict>4080 received packets match initially requested number of Rx descriptors</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="RX-DESCS-ALIGN" notes="net/i40e requires Rx descriptors number to be aligned">
+        <results tags="net_i40e" key="RX-DESCS-ALIGN" notes="net/i40e requires Rx descriptors number to be aligned">
           <result value="SKIPPED">
             <verdict>Rx queue set up failed due to violated descriptors limits</verdict>
           </result>
@@ -29817,7 +29817,7 @@
             <verdict>Received 4032 packets less than initially requested number of Rx descriptors</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="RX-DESCS-9-UNUSED" notes="net/i40e keeps 9 Rx descriptors unused">
+        <results tags="net_i40e" key="RX-DESCS-9-UNUSED" notes="net/i40e keeps 9 Rx descriptors unused">
           <result value="PASSED">
             <verdict>Received 9 packets less than initially requested number of Rx descriptors</verdict>
           </result>
@@ -29853,7 +29853,7 @@
             <verdict>Received 8 packets less than initially requested number of Rx descriptors</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="RX-DESCS-MAX" notes="net/i40e supports up to 4096 Rx descriptors">
+        <results tags="net_i40e" key="RX-DESCS-MAX" notes="net/i40e supports up to 4096 Rx descriptors">
           <result value="SKIPPED">
             <verdict>Rx queue set up failed due to violated descriptors limits</verdict>
           </result>
@@ -29879,7 +29879,7 @@
             <verdict>Received 8 packets less than initially requested number of Rx descriptors</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="RX-DESCS-MAX" notes="net/i40e supports up to 4096 Rx descriptors">
+        <results tags="net_i40e" key="RX-DESCS-MAX" notes="net/i40e supports up to 4096 Rx descriptors">
           <result value="SKIPPED">
             <verdict>Rx queue set up failed due to violated descriptors limits</verdict>
           </result>
@@ -29900,7 +29900,7 @@
             <verdict>Rx queue set up failed due to violated descriptors limits</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="RX-DESCS-MAX" notes="net/i40e supports up to 4096 Rx descriptors">
+        <results tags="net_i40e" key="RX-DESCS-MAX" notes="net/i40e supports up to 4096 Rx descriptors">
           <result value="SKIPPED">
             <verdict>Rx queue set up failed due to violated descriptors limits</verdict>
           </result>
@@ -29961,7 +29961,7 @@
             <verdict>Get queue info isn't supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="TXD-SPACE-1" notes="intel/i40e keeps 1 TxD unused if ring size is a power of 2">
+        <results tags="net_i40e" key="TXD-SPACE-1" notes="intel/i40e keeps 1 TxD unused if ring size is a power of 2">
           <result value="PASSED">
             <verdict>Sent 1 packets less than initially requested number of Tx descriptors</verdict>
           </result>
@@ -29983,7 +29983,7 @@
             <verdict>Get queue info isn't supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="TXD-SPACE-1" notes="intel/i40e keeps 1 TxD unused if ring size is a power of 2">
+        <results tags="net_i40e" key="TXD-SPACE-1" notes="intel/i40e keeps 1 TxD unused if ring size is a power of 2">
           <result value="PASSED">
             <verdict>Sent 1 packets less than initially requested number of Tx descriptors</verdict>
           </result>
@@ -30005,7 +30005,7 @@
             <verdict>Get queue info isn't supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="TXD-SPACE-1" notes="intel/i40e keeps 1 TxD unused if ring size is a power of 2">
+        <results tags="net_i40e" key="TXD-SPACE-1" notes="intel/i40e keeps 1 TxD unused if ring size is a power of 2">
           <result value="PASSED">
             <verdict>Sent 1 packets less than initially requested number of Tx descriptors</verdict>
           </result>
@@ -30064,7 +30064,7 @@
             <verdict>Sent 256 packets less than initially requested number of Tx descriptors</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="TXD-SPACE-1" notes="intel/i40e keeps 1 TxD unused if ring size is a power of 2">
+        <results tags="net_i40e" key="TXD-SPACE-1" notes="intel/i40e keeps 1 TxD unused if ring size is a power of 2">
           <result value="PASSED">
             <verdict>Sent 1 packets less than initially requested number of Tx descriptors</verdict>
           </result>
@@ -30209,7 +30209,7 @@
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for tagged packet when VLAN stripping is supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
+        <results tags="net_i40e" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
           <result value="PASSED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for tagged packet when VLAN stripping is supported</verdict>
           </result>
@@ -30226,7 +30226,7 @@
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for tagged packet when VLAN stripping is supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
+        <results tags="net_i40e" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
           <result value="PASSED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for tagged packet when VLAN stripping is supported</verdict>
           </result>
@@ -30248,7 +30248,7 @@
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
+        <results tags="net_i40e" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
           <result value="FAILED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
             <verdict>RTE_MBUF_F_RX_QINQ flag is not set for double-tagged packet when QinQ stripping is supported</verdict>
@@ -30271,7 +30271,7 @@
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
+        <results tags="net_i40e" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
           <result value="FAILED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
             <verdict>RTE_MBUF_F_RX_QINQ flag is not set for double-tagged packet when QinQ stripping is supported</verdict>
@@ -30294,7 +30294,7 @@
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for tagged packet when VLAN stripping is supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
+        <results tags="net_i40e" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
           <result value="PASSED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for tagged packet when VLAN stripping is supported</verdict>
           </result>
@@ -30316,7 +30316,7 @@
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
+        <results tags="net_i40e" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
           <result value="FAILED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
             <verdict>RTE_MBUF_F_RX_QINQ flag is not set for double-tagged packet when QinQ stripping is supported</verdict>
@@ -30368,7 +30368,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
+        <results tags="net_i40e" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
           <result value="PASSED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for tagged packet when VLAN stripping is supported</verdict>
           </result>
@@ -30415,7 +30415,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -30452,7 +30452,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
+        <results tags="net_i40e" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
           <result value="FAILED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for double-tagged packet when VLAN stripping is supported</verdict>
             <verdict>RTE_MBUF_F_RX_QINQ flag is not set for double-tagged packet when QinQ stripping is supported</verdict>
@@ -30500,7 +30500,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -30695,7 +30695,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -30779,7 +30779,7 @@
             <verdict>The operation to add a tunnel UDP port is unsupported</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -30946,7 +30946,7 @@
             <verdict>QinQ strip is requested but not available</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -31037,7 +31037,7 @@
             <verdict>QinQ strip is requested but not available</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -31155,7 +31155,7 @@
             <verdict>QinQ strip is requested but not available</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
+        <results tags="net_i40e" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
           <result value="PASSED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for tagged packet when VLAN stripping is supported</verdict>
           </result>
@@ -31187,7 +31187,7 @@
             <verdict>QinQ strip is requested but not available</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
+        <results tags="net_i40e" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
           <result value="PASSED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for tagged packet when VLAN stripping is supported</verdict>
           </result>
@@ -31273,7 +31273,7 @@
             <verdict>QinQ strip is requested but not available</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
+        <results tags="net_i40e" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
           <result value="PASSED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for tagged packet when VLAN stripping is supported</verdict>
           </result>
@@ -31305,7 +31305,7 @@
             <verdict>QinQ strip is requested but not available</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
@@ -31342,7 +31342,7 @@
             <verdict>QinQ strip is requested but not available</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
+        <results tags="net_i40e" key="NO-RX-VLAN-WO-STRIPPING" notes="i40e does not provide VLAN TCI without stripping">
           <result value="PASSED">
             <verdict>RTE_MBUF_F_RX_VLAN flag is not set for tagged packet when VLAN stripping is supported</verdict>
           </result>
@@ -31401,7 +31401,7 @@
             <verdict>QinQ strip is requested but not available</verdict>
           </result>
         </results>
-        <results tags="pci-8086-1572|pci-8086-1583" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
+        <results tags="net_i40e" key="GENEVE" notes="net/i40e does not support GENEVE tunnels">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>

--- a/trc/usecases.xml
+++ b/trc/usecases.xml
@@ -17183,6 +17183,14 @@
             <verdict>Packet type is wrong</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="RX-VXLAN-PTYPE-L4-OUTER" notes="net/i40e does not report outer L4 as UDP in VXLAN case">
+          <result value="FAILED">
+            <verdict>Inner layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got INNER_L2_ETHER, must be INNER_L2_UNKNOWN</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -20217,6 +20225,13 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="RX-VXLAN-PTYPE-L4-OUTER" notes="net/i40e does not report outer L4 as UDP in VXLAN case">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -20269,6 +20284,13 @@
         <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="RX-VXLAN-PTYPE-L4-OUTER" notes="net/i40e does not report outer L4 as UDP in VXLAN case">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type is wrong</verdict>
           </result>
         </results>
       </iter>
@@ -20388,6 +20410,13 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="RX-VXLAN-PTYPE-L4-OUTER" notes="net/i40e does not report outer L4 as UDP in VXLAN case">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -20442,6 +20471,13 @@
         <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="RX-VXLAN-PTYPE-L4-OUTER" notes="net/i40e does not report outer L4 as UDP in VXLAN case">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type is wrong</verdict>
           </result>
         </results>
       </iter>
@@ -20500,6 +20536,13 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="RX-VXLAN-PTYPE-L4-OUTER" notes="net/i40e does not report outer L4 as UDP in VXLAN case">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -20554,6 +20597,13 @@
         <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="RX-VXLAN-PTYPE-L4-OUTER" notes="net/i40e does not report outer L4 as UDP in VXLAN case">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type is wrong</verdict>
           </result>
         </results>
       </iter>
@@ -20612,6 +20662,13 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="RX-VXLAN-PTYPE-L4-OUTER" notes="net/i40e does not report outer L4 as UDP in VXLAN case">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -20668,6 +20725,13 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="RX-VXLAN-PTYPE-L4-OUTER" notes="net/i40e does not report outer L4 as UDP in VXLAN case">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -20721,6 +20785,12 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="RX-VXLAN-PTYPE-L4-OUTER" notes="net/i40e does not report outer L4 as UDP in VXLAN case">
+          <result value="FAILED">
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -20772,6 +20842,12 @@
         <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="RX-VXLAN-PTYPE-L4-OUTER" notes="net/i40e does not report outer L4 as UDP in VXLAN case">
+          <result value="FAILED">
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type is wrong</verdict>
           </result>
         </results>
       </iter>
@@ -20888,6 +20964,12 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="RX-VXLAN-PTYPE-L4-OUTER" notes="net/i40e does not report outer L4 as UDP in VXLAN case">
+          <result value="FAILED">
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -20941,6 +21023,12 @@
         <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="RX-VXLAN-PTYPE-L4-OUTER" notes="net/i40e does not report outer L4 as UDP in VXLAN case">
+          <result value="FAILED">
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type is wrong</verdict>
           </result>
         </results>
       </iter>
@@ -20998,6 +21086,12 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="RX-VXLAN-PTYPE-L4-OUTER" notes="net/i40e does not report outer L4 as UDP in VXLAN case">
+          <result value="FAILED">
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -21051,6 +21145,12 @@
         <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="RX-VXLAN-PTYPE-L4-OUTER" notes="net/i40e does not report outer L4 as UDP in VXLAN case">
+          <result value="FAILED">
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type is wrong</verdict>
           </result>
         </results>
       </iter>
@@ -21108,6 +21208,12 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="RX-VXLAN-PTYPE-L4-OUTER" notes="net/i40e does not report outer L4 as UDP in VXLAN case">
+          <result value="FAILED">
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -21161,6 +21267,12 @@
         <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="RX-VXLAN-PTYPE-L4-OUTER" notes="net/i40e does not report outer L4 as UDP in VXLAN case">
+          <result value="FAILED">
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type is wrong</verdict>
           </result>
         </results>
       </iter>
@@ -25394,6 +25506,13 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="RX-VXLAN-PTYPE-L4-OUTER" notes="net/i40e does not report outer L4 as UDP in VXLAN case">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -25446,6 +25565,13 @@
         <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="RX-VXLAN-PTYPE-L4-OUTER" notes="net/i40e does not report outer L4 as UDP in VXLAN case">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type is wrong</verdict>
           </result>
         </results>
       </iter>
@@ -25565,6 +25691,13 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="RX-VXLAN-PTYPE-L4-OUTER" notes="net/i40e does not report outer L4 as UDP in VXLAN case">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -25619,6 +25752,13 @@
         <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="RX-VXLAN-PTYPE-L4-OUTER" notes="net/i40e does not report outer L4 as UDP in VXLAN case">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type is wrong</verdict>
           </result>
         </results>
       </iter>
@@ -25677,6 +25817,13 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="RX-VXLAN-PTYPE-L4-OUTER" notes="net/i40e does not report outer L4 as UDP in VXLAN case">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -25731,6 +25878,13 @@
         <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="RX-VXLAN-PTYPE-L4-OUTER" notes="net/i40e does not report outer L4 as UDP in VXLAN case">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type is wrong</verdict>
           </result>
         </results>
       </iter>
@@ -25789,6 +25943,13 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="RX-VXLAN-PTYPE-L4-OUTER" notes="net/i40e does not report outer L4 as UDP in VXLAN case">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -25845,6 +26006,13 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="RX-VXLAN-PTYPE-L4-OUTER" notes="net/i40e does not report outer L4 as UDP in VXLAN case">
+          <result value="FAILED">
+            <verdict>Layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -25896,6 +26064,12 @@
         <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="RX-VXLAN-PTYPE-L4-OUTER" notes="net/i40e does not report outer L4 as UDP in VXLAN case">
+          <result value="FAILED">
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type is wrong</verdict>
           </result>
         </results>
       </iter>
@@ -25951,6 +26125,12 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="RX-VXLAN-PTYPE-L4-OUTER" notes="net/i40e does not report outer L4 as UDP in VXLAN case">
+          <result value="FAILED">
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -26004,6 +26184,14 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="RX-VXLAN-PTYPE-L4-OUTER" notes="net/i40e does not report outer L4 as UDP in VXLAN case">
+          <result value="FAILED">
+            <verdict>Inner layer 2 packet type is unsupported by the driver</verdict>
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type mismatch: got INNER_L2_ETHER, must be INNER_L2_UNKNOWN</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -26055,6 +26243,12 @@
         <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="RX-VXLAN-PTYPE-L4-OUTER" notes="net/i40e does not report outer L4 as UDP in VXLAN case">
+          <result value="FAILED">
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type is wrong</verdict>
           </result>
         </results>
       </iter>
@@ -26112,6 +26306,12 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="RX-VXLAN-PTYPE-L4-OUTER" notes="net/i40e does not report outer L4 as UDP in VXLAN case">
+          <result value="FAILED">
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -26165,6 +26365,12 @@
         <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="RX-VXLAN-PTYPE-L4-OUTER" notes="net/i40e does not report outer L4 as UDP in VXLAN case">
+          <result value="FAILED">
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type is wrong</verdict>
           </result>
         </results>
       </iter>
@@ -26222,6 +26428,12 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="RX-VXLAN-PTYPE-L4-OUTER" notes="net/i40e does not report outer L4 as UDP in VXLAN case">
+          <result value="FAILED">
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -26277,6 +26489,12 @@
             <verdict>Failed to add a tunnel UDP port</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="RX-VXLAN-PTYPE-L4-OUTER" notes="net/i40e does not report outer L4 as UDP in VXLAN case">
+          <result value="FAILED">
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type is wrong</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>
@@ -26330,6 +26548,12 @@
         <results tags="pci-1924-1a03|pci-1924-1b03" key="EF10-VF-NO-UDP-TUNNEL" notes="Tunnel UDP port configuration is not supported on EF10 VFs">
           <result value="FAILED">
             <verdict>Failed to add a tunnel UDP port</verdict>
+          </result>
+        </results>
+        <results tags="net_i40e" key="RX-VXLAN-PTYPE-L4-OUTER" notes="net/i40e does not report outer L4 as UDP in VXLAN case">
+          <result value="FAILED">
+            <verdict>Packet type mismatch: got L4_UNKNOWN, must be L4_UDP</verdict>
+            <verdict>Packet type is wrong</verdict>
           </result>
         </results>
       </iter>

--- a/trc/usecases.xml
+++ b/trc/usecases.xml
@@ -9426,6 +9426,12 @@
             <verdict>Rx IP checksum offload is unsupported</verdict>
           </result>
         </results>
+        <results tags="net_i40e" key="ICMP4-RX_L4_CKSUM_GOOD" notes="net/i40e always report RX_L4_CKSUM_GOOD for ICMPv4 packets">
+          <result value="FAILED">
+            <verdict>Unexpected checksum offload flags for the packet with good checksums: expected RTE_MBUF_F_RX_L4_CKSUM_UNKNOWN VS obtained RTE_MBUF_F_RX_L4_CKSUM_GOOD</verdict>
+            <verdict>Unexpected checksum offload flags for the packet with bad checksums: expected RTE_MBUF_F_RX_L4_CKSUM_UNKNOWN VS obtained RTE_MBUF_F_RX_L4_CKSUM_GOOD</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="env"/>

--- a/trc/usecases.xml
+++ b/trc/usecases.xml
@@ -26318,7 +26318,7 @@
             <verdict>Correct RSS configuration has been rejected on configuration stage</verdict>
           </result>
         </results>
-        <results tags="net_i40e" key="ref://dpdk-bz/1113" notes="i40e: device configure ignores RSS key in rx_adv_conf">
+        <results tags="net_i40e&amp;dpdk&lt;23110002" key="ref://dpdk-bz/1113" notes="i40e: device configure ignores RSS key in rx_adv_conf">
           <result value="FAILED">
             <verdict>Bogus RSS key size has been accepted</verdict>
           </result>

--- a/ts/lib/dpdk_pmd_ts.c
+++ b/ts/lib/dpdk_pmd_ts.c
@@ -4378,7 +4378,7 @@ test_setup_rss_configuration(tarpc_rss_hash_protos_t hf,
     };
     unsigned int i;
 
-    rss_conf->rss_key.rss_key_val = tapi_malloc(rss_key_sz);
+    rss_conf->rss_key.rss_key_val = tapi_malloc_or_null(rss_key_sz);
     rss_conf->rss_key.rss_key_len = rss_key_sz;
     rss_conf->rss_key_len = rss_key_sz;
     rss_conf->rss_hf = hf;
@@ -6304,7 +6304,7 @@ void
 test_rx_mq_rss_prepare(struct test_ethdev_config *ec,
                        tarpc_rss_hash_protos_t hash_protos)
 {
-    size_t key_sz = MAX(ec->dev_info.hash_key_size, RPC_RSS_HASH_KEY_LEN_DEF);
+    size_t key_sz = ec->dev_info.hash_key_size;
     struct tarpc_rte_eth_rss_conf *effective_conf;
     struct tarpc_rte_eth_rss_conf *initial_conf;
     struct test_rx_mq_rss *rss;
@@ -6324,14 +6324,14 @@ test_rx_mq_rss_prepare(struct test_ethdev_config *ec,
     if (initial_conf->rss_key_len != 0)
         TEST_FAIL("Cannot prepare Rx multi-queue RSS configuration twice");
 
-    initial_conf->rss_key.rss_key_val = tapi_malloc(key_sz);
+    initial_conf->rss_key.rss_key_val = tapi_malloc_or_null(key_sz);
     te_fill_buf(initial_conf->rss_key.rss_key_val, key_sz);
     initial_conf->rss_key.rss_key_len = key_sz;
     initial_conf->rss_key_len = key_sz;
     initial_conf->rss_hf = hash_protos;
 
     *effective_conf = *initial_conf;
-    effective_conf->rss_key.rss_key_val = tapi_malloc(key_sz);
+    effective_conf->rss_key.rss_key_val = tapi_malloc_or_null(key_sz);
     memcpy(effective_conf->rss_key.rss_key_val,
            initial_conf->rss_key.rss_key_val, key_sz);
 }

--- a/ts/usecases/io_forward_and_drop.c
+++ b/ts/usecases/io_forward_and_drop.c
@@ -77,8 +77,11 @@ main(int argc, char *argv[])
      */
     metadata = (1ULL << TARPC_RTE_ETH_RX_METADATA_USER_MARK_BIT);
 
-    rpc_rte_eth_rx_metadata_negotiate(iut_rpcs, test_ethdev.port_id,
-                                      &metadata);
+    RPC_AWAIT_IUT_ERROR(iut_rpcs);
+    rc = rpc_rte_eth_rx_metadata_negotiate(iut_rpcs, test_ethdev.port_id,
+                                           &metadata);
+    if (rc != 0 && rc != -TE_RC(TE_RPC, TE_EOPNOTSUPP))
+        TEST_FAIL("Rx metadata negotiate failed: %r", -rc);
 
     TEST_STEP("Prepare state TEST_ETHDEV_STARTED");
     test_ethdev.min_tx_desc = test_ethdev.dev_info.tx_desc_lim.nb_max;

--- a/ts/usecases/io_forward_and_drop.c
+++ b/ts/usecases/io_forward_and_drop.c
@@ -77,8 +77,8 @@ main(int argc, char *argv[])
      */
     metadata = (1ULL << TARPC_RTE_ETH_RX_METADATA_USER_MARK_BIT);
 
-    CHECK_RC(rpc_rte_eth_rx_metadata_negotiate(iut_rpcs, test_ethdev.port_id,
-                                               &metadata));
+    rpc_rte_eth_rx_metadata_negotiate(iut_rpcs, test_ethdev.port_id,
+                                      &metadata);
 
     TEST_STEP("Prepare state TEST_ETHDEV_STARTED");
     test_ethdev.min_tx_desc = test_ethdev.dev_info.tx_desc_lim.nb_max;

--- a/ts/usecases/package.xml
+++ b/ts/usecases/package.xml
@@ -979,13 +979,13 @@
                 <value>256</value>
                 <value>496</value>
                 <value>502</value>
-                <value>512</value>
+                <value reqs="I40E_UNSTABLE">512</value>
                 <value>1000</value>
-                <value>1024</value>
-                <value>2048</value>
-                <value>3584</value>
+                <value reqs="I40E_UNSTABLE">1024</value>
+                <value reqs="I40E_UNSTABLE">2048</value>
+                <value reqs="I40E_UNSTABLE">3584</value>
                 <value>4080</value>
-                <value>4096</value>
+                <value reqs="I40E_UNSTABLE">4096</value>
                 <value>8192</value>
                 <value>16384</value>
                 <value>32768</value>

--- a/ts/usecases/rss.c
+++ b/ts/usecases/rss.c
@@ -100,8 +100,7 @@ main(int argc, char *argv[])
     CHECK_RC(test_get_rss_hf_by_tmpl(tmpl, &hash_functions));
     hash_functions &= ethdev_config.dev_info.flow_type_rss_offloads;
     test_setup_rss_configuration(hash_functions,
-                                 MAX(ethdev_config.dev_info.hash_key_size,
-                                     RPC_RSS_HASH_KEY_LEN_DEF),
+                                 ethdev_config.dev_info.hash_key_size,
                                  TRUE, rss_conf);
 
     TEST_STEP("Start the Ethernet device");

--- a/ts/usecases/tx_descriptor_status.c
+++ b/ts/usecases/tx_descriptor_status.c
@@ -130,6 +130,7 @@ main(int argc, char *argv[])
         TEST_VERDICT("Bad status for the last usable descriptor, must be DONE");
 
     TEST_STEP("Verify reserved descriptors (if any)");
+    nb_txd_eff += txq_config.tx_rs_thresh;
     for (i = nb_txd_eff; i < nb_txd; ++i)
     {
         if (rpc_rte_eth_tx_descriptor_status(iut_rpcs,


### PR DESCRIPTION
TE tag v1.28.0 is required to build it.

Now testing on x710 run produces no unexpected results if --tester-req=!I40E_UNSTABLE is used. Really unstable iterations are marked with the requirement.

Also the update returns testing on virtio_virtio to all expected results. It was few regressions after fixes in DPDK v23.11 related to RSS hash key size checks.

There is also one common feature which adds DPDK driver name as a TRC tag.