### PR TITLE
Loopback mode 1 suppot and few minor improvements

### DIFF
--- a/trc/perf.xml
+++ b/trc/perf.xml
@@ -31,6 +31,41 @@
         <arg name="testpmd_arg_rxfreet"/>
         <arg name="testpmd_arg_txfreet"/>
         <arg name="n_fwd_cores"/>
+        <arg name="testpmd_command_loopback_mode">1</arg>
+        <notes/>
+        <results tags="pci-15b3" key="WONTFIX LOOPBACK-MODE">
+          <result value="SKIPPED">
+            <verdict>Iteration skipped due to unsupported loopback mode by hardware</verdict>
+          </result>
+        </results>
+        <results tags="pci-1af4-1000|pci-1af4-1041">
+          <result value="SKIPPED">
+            <verdict>Iteration skipped due to unsupported loopback mode by hardware</verdict>
+          </result>
+        </results>
+        <results tags="pci-1924-1903|pci-1924-1923|pci-1924-1a03|pci-1924-1b03|pci-10ee-0100" key="WONTFIX HW-NO-LOOPBACK-MODE">
+          <result value="SKIPPED">
+            <verdict>Iteration skipped due to unsupported loopback mode by hardware</verdict>
+          </result>
+        </results>
+        <results tags="pci-8086" key="WONTFIX LOOPBACK-MODE">
+          <result value="SKIPPED">
+            <verdict>Iteration skipped due to unsupported loopback mode by hardware</verdict>
+          </result>
+        </results>
+      </iter>
+      <iter result="PASSED">
+        <arg name="env"/>
+        <arg name="testpmd_arg_forward_mode"/>
+        <arg name="testpmd_arg_tx_first"/>
+        <arg name="testpmd_arg_stats_period"/>
+        <arg name="testpmd_arg_no_lsc_interrupt"/>
+        <arg name="testpmd_arg_txd"/>
+        <arg name="testpmd_command_txpkts"/>
+        <arg name="testpmd_arg_burst"/>
+        <arg name="testpmd_arg_rxfreet"/>
+        <arg name="testpmd_arg_txfreet"/>
+        <arg name="n_fwd_cores"/>
         <arg name="testpmd_command_loopback_mode">3</arg>
         <notes/>
         <results tags="pci-15b3" key="WONTFIX LOOPBACK-MODE">

--- a/ts/lib/dpdk_pmd_ts.c
+++ b/ts/lib/dpdk_pmd_ts.c
@@ -5331,6 +5331,12 @@ test_get_extra_tx_descs_per_pkt(void)
 }
 
 unsigned int
+test_get_min_tx_descs_by_nb_pkts(unsigned int nb_pkts)
+{
+    return nb_pkts * (1 + test_get_extra_tx_descs_per_pkt());
+}
+
+unsigned int
 test_get_tso_payload_cutoff_barrier(unsigned int hdrs_len)
 {
     const char *path = "/local:/dpdk:/tso_cutoff_barrier:";

--- a/ts/lib/dpdk_pmd_ts.c
+++ b/ts/lib/dpdk_pmd_ts.c
@@ -1881,7 +1881,8 @@ test_pt_by_ip6_pdu_choice(const asn_value *ipc,
 
     if (inner_ip6_ext_supported)
     {
-        if ((next_header == IPPROTO_UDP) || (next_header == IPPROTO_TCP))
+        if ((next_header == IPPROTO_UDP) || (next_header == IPPROTO_TCP) ||
+            (next_header == IPPROTO_GRE))
             *l3_inner = TARPC_RTE_PTYPE_INNER_L3_IPV6;
         else
             *l3_inner = TARPC_RTE_PTYPE_INNER_L3_IPV6_EXT;
@@ -1893,7 +1894,8 @@ test_pt_by_ip6_pdu_choice(const asn_value *ipc,
 
     if (outer_ip6_ext_supported)
     {
-        if ((next_header == IPPROTO_UDP) || (next_header == IPPROTO_TCP))
+        if ((next_header == IPPROTO_UDP) || (next_header == IPPROTO_TCP) ||
+            (next_header == IPPROTO_GRE))
             *l3_outer = TARPC_RTE_PTYPE_L3_IPV6;
         else
             *l3_outer = TARPC_RTE_PTYPE_L3_IPV6_EXT;

--- a/ts/lib/dpdk_pmd_ts.h
+++ b/ts/lib/dpdk_pmd_ts.h
@@ -1545,6 +1545,11 @@ extern void test_send_and_match_one_packet_custom_verdicts(rcf_rpc_server *rpcs,
 extern unsigned int test_get_extra_tx_descs_per_pkt(void);
 
 /**
+ * Get minimum number of Tx descriptors to send specified number of packets.
+ */
+extern unsigned int test_get_min_tx_descs_by_nb_pkts(unsigned int nb_pkts);
+
+/**
  * Get TSO payload cutoff barrier (i.e. without net headers length).
  *
  * @param hdrs_len      Net headers length.

--- a/ts/perf/package.xml
+++ b/ts/perf/package.xml
@@ -79,6 +79,7 @@
                 <value>1</value>
             </arg>
             <arg name="testpmd_command_loopback_mode">
+                <value>1</value>
                 <value>3</value>
                 <value>27</value>
                 <value>29</value>

--- a/ts/usecases/rx_offload_checksum.c
+++ b/ts/usecases/rx_offload_checksum.c
@@ -182,6 +182,7 @@ main(int argc, char *argv[])
 
     TEST_STEP("Prepare @c TEST_ETHDEV_INITIALIZED state");
     test_prepare_config_def_mk(&env, iut_rpcs, iut_port, &tec);
+    tec.min_rx_desc = 2 /* tested packets */ + 1;
     CHECK_RC(test_prepare_ethdev(&tec, TEST_ETHDEV_INITIALIZED));
 
     TEST_STEP("Check the capabilities and adjust the expectations of checksum flags");

--- a/ts/usecases/rx_stats.c
+++ b/ts/usecases/rx_stats.c
@@ -80,9 +80,9 @@ main(int argc, char *argv[])
     TEST_GET_LINK_ADDR(mcast_addr);
 
     TEST_STEP("Initialize EAL");
-    CHECK_RC(test_default_prepare_ethdev(&env, iut_rpcs, iut_port,
-                                         &ethdev_config,
-                                         TEST_ETHDEV_INITIALIZED));
+    (void)test_prepare_config_def_mk(&env, iut_rpcs, iut_port, &ethdev_config);
+    ethdev_config.min_rx_desc = nb_pkts + 1;
+    CHECK_RC(test_prepare_ethdev(&ethdev_config, TEST_ETHDEV_INITIALIZED));
 
     TEST_STEP("Start the Ethernet device");
     ethdev_config.required_mtu = payload_len;

--- a/ts/usecases/set_mc_addr_list.c
+++ b/ts/usecases/set_mc_addr_list.c
@@ -99,6 +99,7 @@ main(int argc, char *argv[])
     TEST_STEP("Prepare @p ethdev_state Ethernet device state");
     test_prepare_config_def_mk(&env, iut_rpcs, iut_port,
                                &ethdev_config);
+    ethdev_config.min_rx_desc = MAX(nb_mc_addr, nb_mismatch_addr) + 1;
 
     CHECK_RC(test_prepare_ethdev(&ethdev_config, ethdev_state));
 

--- a/ts/usecases/tx_burst_simple.c
+++ b/ts/usecases/tx_burst_simple.c
@@ -66,7 +66,7 @@ main(int argc, char *argv[])
 
     TEST_STEP("Initialize EAL, preparing of configured Ethernet device state");
     (void)test_prepare_config_def_mk(&env, iut_rpcs, iut_port, &ethdev_config);
-    ethdev_config.min_tx_desc = nb_pkts;
+    ethdev_config.min_tx_desc = test_get_min_tx_descs_by_nb_pkts(nb_pkts);
     CHECK_RC(test_prepare_ethdev(&ethdev_config, TEST_ETHDEV_CONFIGURED));
 
     TEST_STEP("Prepare mbufs to be sent and pattern to match it by @p tmpl");

--- a/ts/usecases/tx_multi_burst.c
+++ b/ts/usecases/tx_multi_burst.c
@@ -79,7 +79,7 @@ main(int argc, char *argv[])
               "using @p nb_queues for set up transmit queues");
     test_prepare_config_def_mk(&env, iut_rpcs, iut_port, &ethdev_config);
     ethdev_config.nb_tx_queue = nb_queues;
-    ethdev_config.min_tx_desc = nb_pkts;
+    ethdev_config.min_tx_desc = test_get_min_tx_descs_by_nb_pkts(nb_pkts);
 
     CHECK_RC(test_prepare_ethdev(&ethdev_config, TEST_ETHDEV_CONFIGURED));
 

--- a/ts/usecases/tx_stats.c
+++ b/ts/usecases/tx_stats.c
@@ -88,7 +88,7 @@ main(int argc, char *argv[])
 
     TEST_STEP("Initialize EAL, preparing of Rx/Tx setup done Ethernet device state");
     (void)test_prepare_config_def_mk(&env, iut_rpcs, iut_port, &ethdev_config);
-    ethdev_config.min_tx_desc = nb_pkts;
+    ethdev_config.min_tx_desc = test_get_min_tx_descs_by_nb_pkts(nb_pkts);
     CHECK_RC(test_prepare_ethdev(&ethdev_config, TEST_ETHDEV_RXTX_SETUP_DONE));
 
     TEST_STEP("Prepare mbufs to be sent and pattern to match it by @p tmpl");

--- a/ts/xmit/alternate_vlan.c
+++ b/ts/xmit/alternate_vlan.c
@@ -166,7 +166,8 @@ main(int argc, char *argv[])
     CHECK_RC(test_mk_txmode_txconf(&ethdev_config, tx_offloads,
                                    &eth_conf.txmode, NULL));
 
-    ethdev_config.min_tx_desc = TEST_TX_PKTS_NUM;
+    ethdev_config.min_tx_desc =
+        test_get_min_tx_descs_by_nb_pkts(TEST_TX_PKTS_NUM);
     CHECK_RC(test_prepare_ethdev(&ethdev_config, TEST_ETHDEV_STARTED));
 
     TEST_STEP("Obtain the source Ethernet address");

--- a/ts/xmit/vlan_txqs_interference.c
+++ b/ts/xmit/vlan_txqs_interference.c
@@ -218,7 +218,8 @@ main(int argc, char *argv[])
 
     ethdev_config.nb_rx_queue = 1;
     ethdev_config.nb_tx_queue = nb_tx_queues;
-    ethdev_config.min_tx_desc = burst_size_per_txq;
+    ethdev_config.min_tx_desc =
+        test_get_min_tx_descs_by_nb_pkts(burst_size_per_txq);
 
     (void)test_rpc_rte_eth_make_eth_conf(iut_rpcs, iut_port->if_index,
                                          &eth_conf);


### PR DESCRIPTION
Existing support for loopback modes definition in ts-conf is inconvenient for debugging and new HW support. Make it more flexible using environment variable.

Also improve usecases to care about minimum required number of Rx/Tx descriptors.