### PR TITLE
ts: fix Rx/Tx deferred queue expectations

### DIFF
--- a/trc/usecases.xml
+++ b/trc/usecases.xml
@@ -10998,19 +10998,24 @@
         <arg name="n_rxq">3</arg>
         <arg name="tmpl"/>
         <notes/>
-        <results tags="pci-8086-1521">
+        <results tags="max_rx_queues&lt;3">
+          <result value="SKIPPED">
+            <verdict>So many Rx queues are not supported</verdict>
+          </result>
+        </results>
+        <results tags="dpdk&lt;25030002&amp;net_e1000_igb">
           <result value="FAILED">
             <verdict>Deferred start has not been applied for RX queue</verdict>
+          </result>
+        </results>
+        <results tags="net_e1000_igb">
+          <result value="FAILED">
+            <verdict>Failed to setup RxQ: EOPNOTSUPP</verdict>
           </result>
         </results>
         <results tags="vdev-bonding">
           <result value="SKIPPED">
             <verdict>Rx queue start operation is not supported</verdict>
-          </result>
-        </results>
-        <results tags="max_rx_queues&lt;3">
-          <result value="SKIPPED">
-            <verdict>So many Rx queues are not supported</verdict>
           </result>
         </results>
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO does not support RSS">
@@ -11029,19 +11034,24 @@
         <arg name="n_rxq">4</arg>
         <arg name="tmpl"/>
         <notes/>
-        <results tags="pci-8086-1521">
+        <results tags="max_rx_queues&lt;4">
+          <result value="SKIPPED">
+            <verdict>So many Rx queues are not supported</verdict>
+          </result>
+        </results>
+        <results tags="dpdk&lt;25030002&amp;net_e1000_igb">
           <result value="FAILED">
             <verdict>Deferred start has not been applied for RX queue</verdict>
+          </result>
+        </results>
+        <results tags="net_e1000_igb">
+          <result value="FAILED">
+            <verdict>Failed to setup RxQ: EOPNOTSUPP</verdict>
           </result>
         </results>
         <results tags="vdev-bonding">
           <result value="SKIPPED">
             <verdict>Rx queue start operation is not supported</verdict>
-          </result>
-        </results>
-        <results tags="max_rx_queues&lt;4">
-          <result value="SKIPPED">
-            <verdict>So many Rx queues are not supported</verdict>
           </result>
         </results>
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO does not support RSS">
@@ -11060,19 +11070,24 @@
         <arg name="n_rxq">7</arg>
         <arg name="tmpl"/>
         <notes/>
-        <results tags="pci-8086-1521">
+        <results tags="max_rx_queues&lt;7">
+          <result value="SKIPPED">
+            <verdict>So many Rx queues are not supported</verdict>
+          </result>
+        </results>
+        <results tags="dpdk&lt;25030002&amp;net_e1000_igb">
           <result value="FAILED">
             <verdict>Deferred start has not been applied for RX queue</verdict>
+          </result>
+        </results>
+        <results tags="net_e1000_igb">
+          <result value="FAILED">
+            <verdict>Failed to setup RxQ: EOPNOTSUPP</verdict>
           </result>
         </results>
         <results tags="vdev-bonding">
           <result value="SKIPPED">
             <verdict>Rx queue start operation is not supported</verdict>
-          </result>
-        </results>
-        <results tags="max_rx_queues&lt;7">
-          <result value="SKIPPED">
-            <verdict>So many Rx queues are not supported</verdict>
           </result>
         </results>
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO does not support RSS">
@@ -11091,19 +11106,24 @@
         <arg name="n_rxq">11</arg>
         <arg name="tmpl"/>
         <notes/>
-        <results tags="pci-8086-1521">
+        <results tags="max_rx_queues&lt;11">
+          <result value="SKIPPED">
+            <verdict>So many Rx queues are not supported</verdict>
+          </result>
+        </results>
+        <results tags="dpdk&lt;25030002&amp;net_e1000_igb">
           <result value="FAILED">
             <verdict>Deferred start has not been applied for RX queue</verdict>
+          </result>
+        </results>
+        <results tags="net_e1000_igb">
+          <result value="FAILED">
+            <verdict>Failed to setup RxQ: EOPNOTSUPP</verdict>
           </result>
         </results>
         <results tags="vdev-bonding">
           <result value="SKIPPED">
             <verdict>Rx queue start operation is not supported</verdict>
-          </result>
-        </results>
-        <results tags="max_rx_queues&lt;11">
-          <result value="SKIPPED">
-            <verdict>So many Rx queues are not supported</verdict>
           </result>
         </results>
         <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="VirtIO does not support RSS">
@@ -11136,9 +11156,19 @@
             <verdict>So many Tx queues are not supported</verdict>
           </result>
         </results>
-        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="net/virtio does not supported deferred TxQ start">
+        <results tags="net_e1000_igb">
+          <result value="FAILED">
+            <verdict>Failed to setup TxQ 0: EOPNOTSUPP</verdict>
+          </result>
+        </results>
+        <results tags="dpdk&lt;25030002&amp;net_virtio" notes="net/virtio does not supported deferred TxQ start">
           <result value="FAILED">
             <verdict>Failed to setup TxQ 0: EINVAL</verdict>
+          </result>
+        </results>
+        <results tags="net_virtio" notes="net/virtio does not supported deferred TxQ start">
+          <result value="FAILED">
+            <verdict>Failed to setup TxQ 0: EOPNOTSUPP</verdict>
           </result>
         </results>
         <results tags="net_i40e" key="ref://dpdk-bz/1102" notes="i40e: enabling Rx/Tx queue deferred start has no effect">
@@ -11163,9 +11193,19 @@
             <verdict>So many Tx queues are not supported</verdict>
           </result>
         </results>
-        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="net/virtio does not supported deferred TxQ start">
+        <results tags="net_e1000_igb">
+          <result value="FAILED">
+            <verdict>Failed to setup TxQ 0: EOPNOTSUPP</verdict>
+          </result>
+        </results>
+        <results tags="dpdk&lt;25030002&amp;net_virtio" notes="net/virtio does not supported deferred TxQ start">
           <result value="FAILED">
             <verdict>Failed to setup TxQ 0: EINVAL</verdict>
+          </result>
+        </results>
+        <results tags="net_virtio" notes="net/virtio does not supported deferred TxQ start">
+          <result value="FAILED">
+            <verdict>Failed to setup TxQ 0: EOPNOTSUPP</verdict>
           </result>
         </results>
         <results tags="net_i40e" key="ref://dpdk-bz/1102" notes="i40e: enabling Rx/Tx queue deferred start has no effect">
@@ -11190,9 +11230,19 @@
             <verdict>So many Tx queues are not supported</verdict>
           </result>
         </results>
-        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="net/virtio does not supported deferred TxQ start">
+        <results tags="net_e1000_igb">
+          <result value="FAILED">
+            <verdict>Failed to setup TxQ 0: EOPNOTSUPP</verdict>
+          </result>
+        </results>
+        <results tags="dpdk&lt;25030002&amp;net_virtio" notes="net/virtio does not supported deferred TxQ start">
           <result value="FAILED">
             <verdict>Failed to setup TxQ 0: EINVAL</verdict>
+          </result>
+        </results>
+        <results tags="net_virtio" notes="net/virtio does not supported deferred TxQ start">
+          <result value="FAILED">
+            <verdict>Failed to setup TxQ 0: EOPNOTSUPP</verdict>
           </result>
         </results>
         <results tags="net_i40e" key="ref://dpdk-bz/1102" notes="i40e: enabling Rx/Tx queue deferred start has no effect">
@@ -11217,9 +11267,19 @@
             <verdict>So many Tx queues are not supported</verdict>
           </result>
         </results>
-        <results tags="pci-1af4-1000|pci-1af4-1041|pci-1bf4-1000|pci-1bf4-1041" notes="net/virtio does not supported deferred TxQ start">
+        <results tags="net_e1000_igb">
+          <result value="FAILED">
+            <verdict>Failed to setup TxQ 0: EOPNOTSUPP</verdict>
+          </result>
+        </results>
+        <results tags="dpdk&lt;25030002&amp;net_virtio" notes="net/virtio does not supported deferred TxQ start">
           <result value="FAILED">
             <verdict>Failed to setup TxQ 0: EINVAL</verdict>
+          </result>
+        </results>
+        <results tags="net_virtio" notes="net/virtio does not supported deferred TxQ start">
+          <result value="FAILED">
+            <verdict>Failed to setup TxQ 0: EOPNOTSUPP</verdict>
           </result>
         </results>
         <results tags="net_i40e" key="ref://dpdk-bz/1102" notes="i40e: enabling Rx/Tx queue deferred start has no effect">

--- a/ts/lib/dpdk_pmd_ts.c
+++ b/ts/lib/dpdk_pmd_ts.c
@@ -614,6 +614,7 @@ tapi_rte_setup_rx_queues(rcf_rpc_server *rpcs,
 {
     uint16_t queue;
     uint16_t rx_descs = nb_rx_desc;
+    int rc;
 
     if (rx_descs == 0)
     {
@@ -639,9 +640,16 @@ tapi_rte_setup_rx_queues(rcf_rpc_server *rpcs,
 
     for (queue = 0; queue < nb_rx_queue; queue++)
     {
-        rpc_rte_eth_rx_queue_setup(rpcs, port_id, queue, rx_descs, socket_id,
-                                   (rx_confs == NULL) ? NULL : rx_confs[queue],
-                                   *mp);
+        RPC_AWAIT_IUT_ERROR(rpcs);
+        rc = rpc_rte_eth_rx_queue_setup(rpcs, port_id, queue, rx_descs,
+                                        socket_id,
+                                        (rx_confs == NULL) ? NULL :
+                                            rx_confs[queue],
+                                        *mp);
+        if (rc != 0)
+        {
+            TEST_VERDICT("Failed to setup RxQ: %s", errno_rpc2str(-rc));
+        }
     }
 }
 


### PR DESCRIPTION
Since DPDK v25.03-rc2 (commit f73dd2aa1e16e8994d089593dd3f48cfa9915ea0) generic code checks for deferred queue start support based on queue start operation availability and returns -ENOTSUP (aka -EOPNOTSUPP) instead of -EINVAL as many drivers do.

Switch to driver name based TRC tags since deferred queue start are driver features.