### PR TITLE
Fixes for Virtio and automatic tags for maximum number of queues

### DIFF
--- a/trc/usecases.xml
+++ b/trc/usecases.xml
@@ -34611,6 +34611,11 @@
             <verdict>Failed to bring link up (taget FEC mode)</verdict>
           </result>
         </results>
+        <results tags="net_virtio" notes="VirtIO PMD does not support FEC">
+          <result value="SKIPPED">
+            <verdict>No support for querying current FEC mode</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="ethdev_state">CONFIGURED</arg>
@@ -34624,6 +34629,11 @@
             <verdict>No support for querying speed FEC capabilities</verdict>
           </result>
         </results>
+        <results tags="net_virtio" notes="VirtIO PMD does not support FEC">
+          <result value="SKIPPED">
+            <verdict>No support for querying current FEC mode</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="ethdev_state">CONFIGURED</arg>
@@ -34635,6 +34645,11 @@
         <results tags="pci-8086-1572" key="FEC" notes="Intel X710 10GbE does not support FEC">
           <result value="SKIPPED">
             <verdict>No support for querying speed FEC capabilities</verdict>
+          </result>
+        </results>
+        <results tags="net_virtio" notes="VirtIO PMD does not support FEC">
+          <result value="SKIPPED">
+            <verdict>No support for querying current FEC mode</verdict>
           </result>
         </results>
       </iter>
@@ -34653,6 +34668,11 @@
         <results tags="pci-1924" notes="RS is not meant for 10G">
           <result value="SKIPPED">
             <verdict>No support for the target link + FEC mode</verdict>
+          </result>
+        </results>
+        <results tags="net_virtio" notes="VirtIO PMD does not support FEC">
+          <result value="SKIPPED">
+            <verdict>No support for querying current FEC mode</verdict>
           </result>
         </results>
       </iter>
@@ -34673,6 +34693,11 @@
             <verdict>Failed to bring link up (taget FEC mode)</verdict>
           </result>
         </results>
+        <results tags="net_virtio" notes="VirtIO PMD does not support FEC">
+          <result value="SKIPPED">
+            <verdict>No support for querying current FEC mode</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="ethdev_state">STARTED</arg>
@@ -34686,6 +34711,11 @@
             <verdict>No support for querying speed FEC capabilities</verdict>
           </result>
         </results>
+        <results tags="net_virtio" notes="VirtIO PMD does not support FEC">
+          <result value="SKIPPED">
+            <verdict>No support for querying current FEC mode</verdict>
+          </result>
+        </results>
       </iter>
       <iter result="PASSED">
         <arg name="ethdev_state">STARTED</arg>
@@ -34697,6 +34727,11 @@
         <results tags="pci-8086-1572" key="FEC" notes="Intel X710 10GbE does not support FEC">
           <result value="SKIPPED">
             <verdict>No support for querying speed FEC capabilities</verdict>
+          </result>
+        </results>
+        <results tags="net_virtio" notes="VirtIO PMD does not support FEC">
+          <result value="SKIPPED">
+            <verdict>No support for querying current FEC mode</verdict>
           </result>
         </results>
       </iter>
@@ -34715,6 +34750,11 @@
         <results tags="pci-1924" notes="RS is not meant for 10G">
           <result value="SKIPPED">
             <verdict>No support for the target link + FEC mode</verdict>
+          </result>
+        </results>
+        <results tags="net_virtio" notes="VirtIO PMD does not support FEC">
+          <result value="SKIPPED">
+            <verdict>No support for querying current FEC mode</verdict>
           </result>
         </results>
       </iter>

--- a/trc/usecases.xml
+++ b/trc/usecases.xml
@@ -8403,6 +8403,11 @@
             <verdict>Flow control get operation is not supported</verdict>
           </result>
         </results>
+        <results tags="peer-qemu-virtio-net" notes="VirtIO device does not support flow control operations">
+          <result value="SKIPPED">
+            <verdict>Flow control operations are not supported on partner</verdict>
+          </result>
+        </results>
         <results tags="net_virtio" notes="VirtIO PMD does not support flow control get operation">
           <result value="SKIPPED">
             <verdict>Flow control get operation is not supported</verdict>
@@ -8438,6 +8443,11 @@
         <results tags="net_ice" key="NO-FLOW-CTRL" notes="ice does not support rte_eth_dev_flow_ctrl_get()">
           <result value="SKIPPED">
             <verdict>Flow control get operation is not supported</verdict>
+          </result>
+        </results>
+        <results tags="peer-qemu-virtio-net" notes="VirtIO device does not support flow control operations">
+          <result value="SKIPPED">
+            <verdict>Flow control operations are not supported on partner</verdict>
           </result>
         </results>
         <results tags="net_virtio" notes="VirtIO PMD does not support flow control get operation">
@@ -8477,6 +8487,11 @@
             <verdict>Flow control get operation is not supported</verdict>
           </result>
         </results>
+        <results tags="peer-qemu-virtio-net" notes="VirtIO device does not support flow control operations">
+          <result value="SKIPPED">
+            <verdict>Flow control operations are not supported on partner</verdict>
+          </result>
+        </results>
         <results tags="net_virtio" notes="VirtIO PMD does not support flow control get operation">
           <result value="SKIPPED">
             <verdict>Flow control get operation is not supported</verdict>
@@ -8512,6 +8527,11 @@
         <results tags="net_ice" key="NO-FLOW-CTRL" notes="ice does not support rte_eth_dev_flow_ctrl_get()">
           <result value="SKIPPED">
             <verdict>Flow control get operation is not supported</verdict>
+          </result>
+        </results>
+        <results tags="peer-qemu-virtio-net" notes="VirtIO device does not support flow control operations">
+          <result value="SKIPPED">
+            <verdict>Flow control operations are not supported on partner</verdict>
           </result>
         </results>
         <results tags="net_virtio" notes="VirtIO PMD does not support flow control get operation">
@@ -8555,6 +8575,11 @@
             <verdict>Flow control get operation is not supported</verdict>
           </result>
         </results>
+        <results tags="peer-qemu-virtio-net" notes="VirtIO device does not support flow control operations">
+          <result value="SKIPPED">
+            <verdict>Flow control operations are not supported on partner</verdict>
+          </result>
+        </results>
         <results tags="net_virtio" notes="VirtIO PMD does not support flow control get operation">
           <result value="SKIPPED">
             <verdict>Flow control get operation is not supported</verdict>
@@ -8590,6 +8615,11 @@
         <results tags="net_ice" key="NO-FLOW-CTRL" notes="ice does not support rte_eth_dev_flow_ctrl_get()">
           <result value="SKIPPED">
             <verdict>Flow control get operation is not supported</verdict>
+          </result>
+        </results>
+        <results tags="peer-qemu-virtio-net" notes="VirtIO device does not support flow control operations">
+          <result value="SKIPPED">
+            <verdict>Flow control operations are not supported on partner</verdict>
           </result>
         </results>
         <results tags="net_virtio" notes="VirtIO PMD does not support flow control get operation">
@@ -8634,6 +8664,11 @@
             <verdict>Flow control get operation is not supported</verdict>
           </result>
         </results>
+        <results tags="peer-qemu-virtio-net" notes="VirtIO device does not support flow control operations">
+          <result value="SKIPPED">
+            <verdict>Flow control operations are not supported on partner</verdict>
+          </result>
+        </results>
         <results tags="net_virtio" notes="VirtIO PMD does not support flow control get operation">
           <result value="SKIPPED">
             <verdict>Flow control get operation is not supported</verdict>
@@ -8674,6 +8709,11 @@
         <results tags="net_ice" key="NO-FLOW-CTRL" notes="ice does not support rte_eth_dev_flow_ctrl_get()">
           <result value="SKIPPED">
             <verdict>Flow control get operation is not supported</verdict>
+          </result>
+        </results>
+        <results tags="peer-qemu-virtio-net" notes="VirtIO device does not support flow control operations">
+          <result value="SKIPPED">
+            <verdict>Flow control operations are not supported on partner</verdict>
           </result>
         </results>
         <results tags="net_virtio" notes="VirtIO PMD does not support flow control get operation">
@@ -8718,6 +8758,11 @@
             <verdict>Flow control get operation is not supported</verdict>
           </result>
         </results>
+        <results tags="peer-qemu-virtio-net" notes="VirtIO device does not support flow control operations">
+          <result value="SKIPPED">
+            <verdict>Flow control operations are not supported on partner</verdict>
+          </result>
+        </results>
         <results tags="net_virtio" notes="VirtIO PMD does not support flow control get operation">
           <result value="SKIPPED">
             <verdict>Flow control get operation is not supported</verdict>
@@ -8758,6 +8803,11 @@
         <results tags="net_ice" key="NO-FLOW-CTRL" notes="ice does not support rte_eth_dev_flow_ctrl_get()">
           <result value="SKIPPED">
             <verdict>Flow control get operation is not supported</verdict>
+          </result>
+        </results>
+        <results tags="peer-qemu-virtio-net" notes="VirtIO device does not support flow control operations">
+          <result value="SKIPPED">
+            <verdict>Flow control operations are not supported on partner</verdict>
           </result>
         </results>
         <results tags="net_virtio" notes="VirtIO PMD does not support flow control get operation">
@@ -8801,6 +8851,11 @@
             <verdict>Flow control get operation is not supported</verdict>
           </result>
         </results>
+        <results tags="peer-qemu-virtio-net" notes="VirtIO device does not support flow control operations">
+          <result value="SKIPPED">
+            <verdict>Flow control operations are not supported on partner</verdict>
+          </result>
+        </results>
         <results tags="net_virtio" notes="VirtIO PMD does not support flow control get operation">
           <result value="SKIPPED">
             <verdict>Flow control get operation is not supported</verdict>
@@ -8836,6 +8891,11 @@
         <results tags="net_ice" key="NO-FLOW-CTRL" notes="ice does not support rte_eth_dev_flow_ctrl_get()">
           <result value="SKIPPED">
             <verdict>Flow control get operation is not supported</verdict>
+          </result>
+        </results>
+        <results tags="peer-qemu-virtio-net" notes="VirtIO device does not support flow control operations">
+          <result value="SKIPPED">
+            <verdict>Flow control operations are not supported on partner</verdict>
           </result>
         </results>
         <results tags="net_virtio" notes="VirtIO PMD does not support flow control get operation">
@@ -8875,6 +8935,11 @@
             <verdict>Flow control get operation is not supported</verdict>
           </result>
         </results>
+        <results tags="peer-qemu-virtio-net" notes="VirtIO device does not support flow control operations">
+          <result value="SKIPPED">
+            <verdict>Flow control operations are not supported on partner</verdict>
+          </result>
+        </results>
         <results tags="net_virtio" notes="VirtIO PMD does not support flow control get operation">
           <result value="SKIPPED">
             <verdict>Flow control get operation is not supported</verdict>
@@ -8910,6 +8975,11 @@
         <results tags="net_ice" key="NO-FLOW-CTRL" notes="ice does not support rte_eth_dev_flow_ctrl_get()">
           <result value="SKIPPED">
             <verdict>Flow control get operation is not supported</verdict>
+          </result>
+        </results>
+        <results tags="peer-qemu-virtio-net" notes="VirtIO device does not support flow control operations">
+          <result value="SKIPPED">
+            <verdict>Flow control operations are not supported on partner</verdict>
           </result>
         </results>
         <results tags="net_virtio" notes="VirtIO PMD does not support flow control get operation">
@@ -8947,6 +9017,11 @@
             <verdict>Flow control get operation is not supported</verdict>
           </result>
         </results>
+        <results tags="peer-qemu-virtio-net" notes="VirtIO device does not support flow control operations">
+          <result value="SKIPPED">
+            <verdict>Flow control operations are not supported on partner</verdict>
+          </result>
+        </results>
         <results tags="net_virtio" notes="VirtIO PMD does not support flow control get operation">
           <result value="SKIPPED">
             <verdict>Flow control get operation is not supported</verdict>
@@ -8987,6 +9062,11 @@
         <results tags="net_ice" key="NO-FLOW-CTRL" notes="ice does not support rte_eth_dev_flow_ctrl_get()">
           <result value="SKIPPED">
             <verdict>Flow control get operation is not supported</verdict>
+          </result>
+        </results>
+        <results tags="peer-qemu-virtio-net" notes="VirtIO device does not support flow control operations">
+          <result value="SKIPPED">
+            <verdict>Flow control operations are not supported on partner</verdict>
           </result>
         </results>
         <results tags="net_virtio" notes="VirtIO PMD does not support flow control get operation">
@@ -9031,6 +9111,11 @@
             <verdict>Flow control get operation is not supported</verdict>
           </result>
         </results>
+        <results tags="peer-qemu-virtio-net" notes="VirtIO device does not support flow control operations">
+          <result value="SKIPPED">
+            <verdict>Flow control operations are not supported on partner</verdict>
+          </result>
+        </results>
         <results tags="net_virtio" notes="VirtIO PMD does not support flow control get operation">
           <result value="SKIPPED">
             <verdict>Flow control get operation is not supported</verdict>
@@ -9071,6 +9156,11 @@
         <results tags="net_ice" key="NO-FLOW-CTRL" notes="ice does not support rte_eth_dev_flow_ctrl_get()">
           <result value="SKIPPED">
             <verdict>Flow control get operation is not supported</verdict>
+          </result>
+        </results>
+        <results tags="peer-qemu-virtio-net" notes="VirtIO device does not support flow control operations">
+          <result value="SKIPPED">
+            <verdict>Flow control operations are not supported on partner</verdict>
           </result>
         </results>
         <results tags="net_virtio" notes="VirtIO PMD does not support flow control get operation">
@@ -9114,6 +9204,11 @@
             <verdict>Flow control get operation is not supported</verdict>
           </result>
         </results>
+        <results tags="peer-qemu-virtio-net" notes="VirtIO device does not support flow control operations">
+          <result value="SKIPPED">
+            <verdict>Flow control operations are not supported on partner</verdict>
+          </result>
+        </results>
         <results tags="net_virtio" notes="VirtIO PMD does not support flow control get operation">
           <result value="SKIPPED">
             <verdict>Flow control get operation is not supported</verdict>
@@ -9146,6 +9241,11 @@
             <verdict>Flow control get operation is not supported</verdict>
           </result>
         </results>
+        <results tags="peer-qemu-virtio-net" notes="VirtIO device does not support flow control operations">
+          <result value="SKIPPED">
+            <verdict>Flow control operations are not supported on partner</verdict>
+          </result>
+        </results>
         <results tags="net_virtio" notes="VirtIO PMD does not support flow control get operation">
           <result value="SKIPPED">
             <verdict>Flow control get operation is not supported</verdict>
@@ -9188,6 +9288,11 @@
             <verdict>Flow control get operation is not supported</verdict>
           </result>
         </results>
+        <results tags="peer-qemu-virtio-net" notes="VirtIO device does not support flow control operations">
+          <result value="SKIPPED">
+            <verdict>Flow control operations are not supported on partner</verdict>
+          </result>
+        </results>
         <results tags="net_virtio" notes="VirtIO PMD does not support flow control get operation">
           <result value="SKIPPED">
             <verdict>Flow control get operation is not supported</verdict>
@@ -9223,6 +9328,11 @@
         <results tags="net_ice" key="NO-FLOW-CTRL" notes="ice does not support rte_eth_dev_flow_ctrl_get()">
           <result value="SKIPPED">
             <verdict>Flow control get operation is not supported</verdict>
+          </result>
+        </results>
+        <results tags="peer-qemu-virtio-net" notes="VirtIO device does not support flow control operations">
+          <result value="SKIPPED">
+            <verdict>Flow control operations are not supported on partner</verdict>
           </result>
         </results>
         <results tags="net_virtio" notes="VirtIO PMD does not support flow control get operation">
@@ -9267,6 +9377,11 @@
             <verdict>Flow control get operation is not supported</verdict>
           </result>
         </results>
+        <results tags="peer-qemu-virtio-net" notes="VirtIO device does not support flow control operations">
+          <result value="SKIPPED">
+            <verdict>Flow control operations are not supported on partner</verdict>
+          </result>
+        </results>
         <results tags="net_virtio" notes="VirtIO PMD does not support flow control get operation">
           <result value="SKIPPED">
             <verdict>Flow control get operation is not supported</verdict>
@@ -9302,6 +9417,11 @@
         <results tags="net_ice" key="NO-FLOW-CTRL" notes="ice does not support rte_eth_dev_flow_ctrl_get()">
           <result value="SKIPPED">
             <verdict>Flow control get operation is not supported</verdict>
+          </result>
+        </results>
+        <results tags="peer-qemu-virtio-net" notes="VirtIO device does not support flow control operations">
+          <result value="SKIPPED">
+            <verdict>Flow control operations are not supported on partner</verdict>
           </result>
         </results>
         <results tags="net_virtio" notes="VirtIO PMD does not support flow control get operation">
@@ -9346,6 +9466,11 @@
             <verdict>Flow control get operation is not supported</verdict>
           </result>
         </results>
+        <results tags="peer-qemu-virtio-net" notes="VirtIO device does not support flow control operations">
+          <result value="SKIPPED">
+            <verdict>Flow control operations are not supported on partner</verdict>
+          </result>
+        </results>
         <results tags="net_virtio" notes="VirtIO PMD does not support flow control get operation">
           <result value="SKIPPED">
             <verdict>Flow control get operation is not supported</verdict>
@@ -9381,6 +9506,11 @@
         <results tags="net_ice" key="NO-FLOW-CTRL" notes="ice does not support rte_eth_dev_flow_ctrl_get()">
           <result value="SKIPPED">
             <verdict>Flow control get operation is not supported</verdict>
+          </result>
+        </results>
+        <results tags="peer-qemu-virtio-net" notes="VirtIO device does not support flow control operations">
+          <result value="SKIPPED">
+            <verdict>Flow control operations are not supported on partner</verdict>
           </result>
         </results>
         <results tags="net_virtio" notes="VirtIO PMD does not support flow control get operation">
@@ -9424,6 +9554,11 @@
             <verdict>Flow control get operation is not supported</verdict>
           </result>
         </results>
+        <results tags="peer-qemu-virtio-net" notes="VirtIO device does not support flow control operations">
+          <result value="SKIPPED">
+            <verdict>Flow control operations are not supported on partner</verdict>
+          </result>
+        </results>
         <results tags="net_virtio" notes="VirtIO PMD does not support flow control get operation">
           <result value="SKIPPED">
             <verdict>Flow control get operation is not supported</verdict>
@@ -9459,6 +9594,11 @@
         <results tags="net_ice" key="NO-FLOW-CTRL" notes="ice does not support rte_eth_dev_flow_ctrl_get()">
           <result value="SKIPPED">
             <verdict>Flow control get operation is not supported</verdict>
+          </result>
+        </results>
+        <results tags="peer-qemu-virtio-net" notes="VirtIO device does not support flow control operations">
+          <result value="SKIPPED">
+            <verdict>Flow control operations are not supported on partner</verdict>
           </result>
         </results>
         <results tags="net_virtio" notes="VirtIO PMD does not support flow control get operation">
@@ -9498,6 +9638,11 @@
             <verdict>Flow control get operation is not supported</verdict>
           </result>
         </results>
+        <results tags="peer-qemu-virtio-net" notes="VirtIO device does not support flow control operations">
+          <result value="SKIPPED">
+            <verdict>Flow control operations are not supported on partner</verdict>
+          </result>
+        </results>
         <results tags="net_virtio" notes="VirtIO PMD does not support flow control get operation">
           <result value="SKIPPED">
             <verdict>Flow control get operation is not supported</verdict>
@@ -9533,6 +9678,11 @@
         <results tags="net_ice" key="NO-FLOW-CTRL" notes="ice does not support rte_eth_dev_flow_ctrl_get()">
           <result value="SKIPPED">
             <verdict>Flow control get operation is not supported</verdict>
+          </result>
+        </results>
+        <results tags="peer-qemu-virtio-net" notes="VirtIO device does not support flow control operations">
+          <result value="SKIPPED">
+            <verdict>Flow control operations are not supported on partner</verdict>
           </result>
         </results>
         <results tags="net_virtio" notes="VirtIO PMD does not support flow control get operation">
@@ -9571,6 +9721,11 @@
             <verdict>Flow control get operation is not supported</verdict>
           </result>
         </results>
+        <results tags="peer-qemu-virtio-net" notes="VirtIO device does not support flow control operations">
+          <result value="SKIPPED">
+            <verdict>Flow control operations are not supported on partner</verdict>
+          </result>
+        </results>
         <results tags="net_virtio" notes="VirtIO PMD does not support flow control get operation">
           <result value="SKIPPED">
             <verdict>Flow control get operation is not supported</verdict>
@@ -9603,6 +9758,11 @@
             <verdict>Flow control get operation is not supported</verdict>
           </result>
         </results>
+        <results tags="peer-qemu-virtio-net" notes="VirtIO device does not support flow control operations">
+          <result value="SKIPPED">
+            <verdict>Flow control operations are not supported on partner</verdict>
+          </result>
+        </results>
         <results tags="net_virtio" notes="VirtIO PMD does not support flow control get operation">
           <result value="SKIPPED">
             <verdict>Flow control get operation is not supported</verdict>
@@ -9645,6 +9805,11 @@
             <verdict>Flow control get operation is not supported</verdict>
           </result>
         </results>
+        <results tags="peer-qemu-virtio-net" notes="VirtIO device does not support flow control operations">
+          <result value="SKIPPED">
+            <verdict>Flow control operations are not supported on partner</verdict>
+          </result>
+        </results>
         <results tags="net_virtio" notes="VirtIO PMD does not support flow control get operation">
           <result value="SKIPPED">
             <verdict>Flow control get operation is not supported</verdict>
@@ -9680,6 +9845,11 @@
         <results tags="net_ice" key="NO-FLOW-CTRL" notes="ice does not support rte_eth_dev_flow_ctrl_get()">
           <result value="SKIPPED">
             <verdict>Flow control get operation is not supported</verdict>
+          </result>
+        </results>
+        <results tags="peer-qemu-virtio-net" notes="VirtIO device does not support flow control operations">
+          <result value="SKIPPED">
+            <verdict>Flow control operations are not supported on partner</verdict>
           </result>
         </results>
         <results tags="net_virtio" notes="VirtIO PMD does not support flow control get operation">
@@ -9724,6 +9894,11 @@
             <verdict>Flow control get operation is not supported</verdict>
           </result>
         </results>
+        <results tags="peer-qemu-virtio-net" notes="VirtIO device does not support flow control operations">
+          <result value="SKIPPED">
+            <verdict>Flow control operations are not supported on partner</verdict>
+          </result>
+        </results>
         <results tags="net_virtio" notes="VirtIO PMD does not support flow control get operation">
           <result value="SKIPPED">
             <verdict>Flow control get operation is not supported</verdict>
@@ -9759,6 +9934,11 @@
         <results tags="net_ice" key="NO-FLOW-CTRL" notes="ice does not support rte_eth_dev_flow_ctrl_get()">
           <result value="SKIPPED">
             <verdict>Flow control get operation is not supported</verdict>
+          </result>
+        </results>
+        <results tags="peer-qemu-virtio-net" notes="VirtIO device does not support flow control operations">
+          <result value="SKIPPED">
+            <verdict>Flow control operations are not supported on partner</verdict>
           </result>
         </results>
         <results tags="net_virtio" notes="VirtIO PMD does not support flow control get operation">
@@ -9803,6 +9983,11 @@
             <verdict>Flow control get operation is not supported</verdict>
           </result>
         </results>
+        <results tags="peer-qemu-virtio-net" notes="VirtIO device does not support flow control operations">
+          <result value="SKIPPED">
+            <verdict>Flow control operations are not supported on partner</verdict>
+          </result>
+        </results>
         <results tags="net_virtio" notes="VirtIO PMD does not support flow control get operation">
           <result value="SKIPPED">
             <verdict>Flow control get operation is not supported</verdict>
@@ -9838,6 +10023,11 @@
         <results tags="net_ice" key="NO-FLOW-CTRL" notes="ice does not support rte_eth_dev_flow_ctrl_get()">
           <result value="SKIPPED">
             <verdict>Flow control get operation is not supported</verdict>
+          </result>
+        </results>
+        <results tags="peer-qemu-virtio-net" notes="VirtIO device does not support flow control operations">
+          <result value="SKIPPED">
+            <verdict>Flow control operations are not supported on partner</verdict>
           </result>
         </results>
         <results tags="net_virtio" notes="VirtIO PMD does not support flow control get operation">

--- a/ts/prologue.c
+++ b/ts/prologue.c
@@ -702,6 +702,7 @@ static te_errno
 add_dpdk_tags(rcf_rpc_server *rpcs, const struct if_nameindex *port)
 {
     struct tarpc_rte_eth_dev_info dev_info = {};
+    char *tag_value;
     te_errno rc;
 
     rpc_rte_eth_dev_info_get(rpcs, port->if_index, &dev_info);
@@ -709,6 +710,28 @@ add_dpdk_tags(rcf_rpc_server *rpcs, const struct if_nameindex *port)
     if (dev_info.driver_name != NULL)
     {
         rc = tapi_tags_add_tag(dev_info.driver_name, NULL);
+        if (rc != 0)
+            return rc;
+    }
+
+    if (dev_info.max_rx_queues != 0)
+    {
+        tag_value = te_string_fmt("%u", dev_info.max_rx_queues);
+
+        rc = tapi_tags_add_tag("max_rx_queues", tag_value);
+        free(tag_value);
+
+        if (rc != 0)
+            return rc;
+    }
+
+    if (dev_info.max_tx_queues != 0)
+    {
+        tag_value = te_string_fmt("%u", dev_info.max_tx_queues);
+
+        rc = tapi_tags_add_tag("max_tx_queues", tag_value);
+        free(tag_value);
+
         if (rc != 0)
             return rc;
     }

--- a/ts/prologue.c
+++ b/ts/prologue.c
@@ -691,19 +691,43 @@ is_dpdk_rpcs(rcf_rpc_server *rpcs)
 }
 
 /**
+ * Add DPDK-specific TRC tags.
+ *
+ * @param rpcs          The RPC server.
+ * @param port          The DPDK interface.
+ *
+ * @retval The status code.
+ */
+static te_errno
+add_dpdk_tags(rcf_rpc_server *rpcs, const struct if_nameindex *port)
+{
+    struct tarpc_rte_eth_dev_info dev_info = {};
+    te_errno rc;
+
+    rpc_rte_eth_dev_info_get(rpcs, port->if_index, &dev_info);
+
+    if (dev_info.driver_name != NULL)
+    {
+        rc = tapi_tags_add_tag(dev_info.driver_name, NULL);
+        if (rc != 0)
+            return rc;
+    }
+
+    return 0;
+}
+
+/**
  * Read out packets queued by an DPDK interface.
  *
  * @param env           The test environment.
  * @param rpcs          The RCP server.
  * @param port          The DPDK interface.
- * @param tags_prefix   TRC tags to add prefix or @c NULL.
  *
  * @retval The status code.
  */
 static te_errno
 clean_dpdk_interface(tapi_env *env, rcf_rpc_server *rpcs,
-                     const struct if_nameindex *port,
-                     const char *tags_prefix)
+                     const struct if_nameindex *port)
 {
     struct test_ethdev_config config;
     te_errno rc;
@@ -714,22 +738,6 @@ clean_dpdk_interface(tapi_env *env, rcf_rpc_server *rpcs,
     rc = test_prepare_ethdev(&config, TEST_ETHDEV_STARTED);
     if (rc != 0)
         return rc;
-
-    if (tags_prefix != NULL)
-    {
-        te_string   tag = TE_STRING_INIT;
-
-        if (config.dev_info.driver_name != NULL)
-        {
-            te_string_append(&tag, "%s%s", tags_prefix,
-                             config.dev_info.driver_name);
-            rc = tapi_tags_add_tag(te_string_value(&tag), NULL);
-            if (rc != 0)
-                return rc;
-        }
-
-        te_string_free(&tag);
-    }
 
     test_rx_clean_queue(rpcs, port->if_index, 0);
 
@@ -948,14 +956,18 @@ main(int argc, char **argv)
         TEST_VERDICT("Failed to initialise EAL interfaces: %r", rc);
 
     TEST_GET_IF(iut_port);
-    rc = clean_dpdk_interface(&env, iut_rpcs, iut_port, "");
+    rc = clean_dpdk_interface(&env, iut_rpcs, iut_port);
     if (rc != 0)
         TEST_VERDICT("Failed to clean the IUT interface: %r", rc);
+
+    rc = add_dpdk_tags(iut_rpcs, iut_port);
+    if (rc != 0)
+        TEST_VERDICT("Failed to add DPDK-specific TRC tags for IUT: %r", rc);
 
     if (is_dpdk_rpcs(tst_rpcs))
     {
         TEST_GET_IF(tst_if);
-        rc = clean_dpdk_interface(&env, tst_rpcs, tst_if, NULL);
+        rc = clean_dpdk_interface(&env, tst_rpcs, tst_if);
         if (rc != 0)
             TEST_VERDICT("Failed to clean the TST interface: %r", rc);
     }

--- a/ts/usecases/flow_ctrl_set.c
+++ b/ts/usecases/flow_ctrl_set.c
@@ -247,8 +247,12 @@ main(int argc, char *argv[])
     TEST_CHECK_UINT64_IS_IN_BOOL3_RANGE(autoneg);
 
     TEST_STEP("Set flow control on the partner to 'autoneg=on, rx=on, tx=on'");
-    CHECK_RC(tapi_cfg_if_fc_autoneg_set_local(tst_host->ta,
-                                              tst_if->if_name, 1));
+    rc = tapi_cfg_if_fc_autoneg_set_local(tst_host->ta, tst_if->if_name, 1);
+    if (TE_RC_GET_ERROR(rc) == TE_ENOENT)
+        TEST_SKIP("Flow control operations are not supported on partner");
+
+    if (rc != 0)
+        TEST_VERDICT("Failed to set flow control on Tester: %r", rc);
 
     CHECK_RC(tapi_cfg_if_fc_rx_set_local(tst_host->ta, tst_if->if_name, 1));
     CHECK_RC(tapi_cfg_if_fc_tx_set_local(tst_host->ta, tst_if->if_name, 1));


### PR DESCRIPTION
Add tags with maximum number of Rx/Tx queues from prologue automatically based on reported device info.
These tags are essential to have correct expectations for test iterations with use many queues.
Make it unnecessary to manually specify these tags in configuration.

Minor fixes for virtio-net in tests and TRC.